### PR TITLE
Only initialize log monitor if Trade Helper is enabled in settings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,11 @@ class XenonTrade {
   * Initializes listeners for Path of Exile log file
   */
   initializePoeLogMonitor(logfile = config.get("tradehelper.logfile")) {
-    if (config.get("tradehelper.enabled") && fs.existsSync(logfile) && logfile.includes("Client.txt")) {
+    if (!config.get("tradehelper.enabled")) {
+      return;
+    }
+
+    if (fs.existsSync(logfile) && logfile.includes("Client.txt")) {
       // Remove old listeners
       if(poeLog != null) {
         poeLog.pause();


### PR DESCRIPTION
Right now the user gets an "Invalid log file path" error if they've disabled TradeHelper