### PR TITLE
Implemented option to use different providers for checking item prices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "XenonTrade",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "7zip-bin": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-4.0.2.tgz",
-      "integrity": "sha512-XtGk+IF57pr852UK1AhQJXqmm1WmSgS5uISL+LPs0z/iAxXouMvdlLJrHPeukP6gd7yR2rDTMSMkHNODgwIq7A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-4.1.0.tgz",
+      "integrity": "sha512-AsnBZN3a8/JcNt+KPkGGODaA4c7l3W5+WpeKgGSbstSLxqWtTXqd1ieJGBQ8IFCtRg8DmmKUcSkIkUc0A4p3YA==",
       "dev": true
     },
     "@octetstream/promisify": {
@@ -15,15 +15,37 @@
       "resolved": "https://registry.npmjs.org/@octetstream/promisify/-/promisify-1.1.0.tgz",
       "integrity": "sha512-+ns1dHOaK4f8tvgf8uAkyuvdG+o9QkSQzLNU/a36cDPxKhORHCK0xNQ+GQb4ZOU8ouSS8akvfaKdJmZP5PrPow=="
     },
+    "@sindresorhus/is": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+      "dev": true
+    },
+    "@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "dev": true,
+      "requires": {
+        "defer-to-connect": "^1.0.1"
+      }
+    },
+    "@types/debug": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.4.tgz",
+      "integrity": "sha512-D9MyoQFI7iP5VdpEyPZyjjqIJ8Y8EDNQFIFVLOmeg1rI1xiHOChyUPMPRUVfqFCerxfE+yS3vMyj37F6IdtOoQ==",
+      "dev": true
+    },
     "@types/node": {
-      "version": "7.0.70",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.70.tgz",
-      "integrity": "sha512-bAcW/1aM8/s5iFKhRpu/YJiQf/b1ZwnMRqqsWRCmAqEDQF2zY8Ez3Iu9AcZKFKc3vCJc8KJVpJ6Pn54sJ1BvXQ=="
+      "version": "8.10.49",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.49.tgz",
+      "integrity": "sha512-YX30JVx0PvSmJ3Eqr74fYLGeBxD+C7vIL20ek+GGGLJeUbVYRUW3EzyAXpIRA0K8c8o0UWqR/GwEFYiFoz1T8w==",
+      "dev": true
     },
     "active-win": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/active-win/-/active-win-3.0.0.tgz",
-      "integrity": "sha512-mGu43BZO7j3TPeniPHoq7qtXNqMtOh4gihG+Y+mFZv3TPovYxfOgUkGuuIvYleK+hYvRVzDYb+wEv5jd/F14/Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/active-win/-/active-win-3.0.1.tgz",
+      "integrity": "sha512-pMjwsX+jBGi4wjxPk0jqW+JQ31khObz/iGAniCCmtoGwMCYe4JdXUuJV0bHCjphvdqBEMCKKz9G4p+IfMawLmg==",
       "requires": {
         "ffi": "^2.2.0",
         "pify": "^3.0.0",
@@ -43,24 +65,24 @@
       }
     },
     "ajv-keywords": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-      "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
+      "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
       "dev": true
     },
     "ansi-align": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
+      "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
       "dev": true,
       "requires": {
-        "string-width": "^2.0.0"
+        "string-width": "^3.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -70,22 +92,23 @@
           "dev": true
         },
         "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
+            "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -106,51 +129,63 @@
       }
     },
     "app-builder-bin": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-2.1.2.tgz",
-      "integrity": "sha512-PZJspzAqB0+z60OalXChP9I05BzODd/ffDz6RvTmDG3qclr7YrnpqzvPF+T7vGVtk2nN7syuveTQROJfXcB8xA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-2.7.1.tgz",
+      "integrity": "sha512-ubIBeiL9XysjMW4HETBKxj3DC8ika6dGyC0vftPc0kZwGh1iXQ5bycsjoAqY/3t3BBEEIg0VruicvBaUl1pOSQ==",
       "dev": true
     },
     "app-builder-lib": {
-      "version": "20.28.3",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-20.28.3.tgz",
-      "integrity": "sha512-oZqv3+oi5bfKbN5eFfEbNovSuMTXn3yu8yJbmqDCNXcI1caOF+hCNAUpgMFohNGO0uY80veAwQTysZ74/VFjCA==",
+      "version": "20.44.4",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-20.44.4.tgz",
+      "integrity": "sha512-1K1xfrhyqDgnibwyuYMgvfwGilGLMF31YwOUJ8IXreyjRef9lUjWW+BZuBXqk4Uqd0C0EYPjhofgpuN0WoAQ+A==",
       "dev": true,
       "requires": {
-        "7zip-bin": "~4.0.2",
-        "app-builder-bin": "2.1.2",
+        "7zip-bin": "~4.1.0",
+        "app-builder-bin": "2.7.1",
         "async-exit-hook": "^2.0.1",
-        "bluebird-lst": "^1.0.5",
-        "builder-util": "6.1.3",
-        "builder-util-runtime": "4.4.1",
+        "bluebird-lst": "^1.0.9",
+        "builder-util": "10.1.2",
+        "builder-util-runtime": "8.2.5",
         "chromium-pickle-js": "^0.2.0",
-        "debug": "^3.1.0",
-        "ejs": "^2.6.1",
-        "electron-osx-sign": "0.4.10",
-        "electron-publish": "20.28.3",
-        "fs-extra-p": "^4.6.1",
+        "debug": "^4.1.1",
+        "ejs": "^2.6.2",
+        "electron-osx-sign": "0.4.11",
+        "electron-publish": "20.44.4",
+        "fs-extra-p": "^8.0.2",
         "hosted-git-info": "^2.7.1",
-        "is-ci": "^1.2.0",
-        "isbinaryfile": "^3.0.3",
-        "js-yaml": "^3.12.0",
-        "lazy-val": "^1.0.3",
+        "is-ci": "^2.0.0",
+        "isbinaryfile": "^4.0.1",
+        "js-yaml": "^3.13.1",
+        "lazy-val": "^1.0.4",
         "minimatch": "^3.0.4",
-        "normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
         "plist": "^3.0.1",
-        "read-config-file": "3.1.2",
+        "read-config-file": "3.2.2",
         "sanitize-filename": "^1.6.1",
-        "semver": "^5.5.1",
-        "temp-file": "^3.1.3"
+        "semver": "^6.1.1",
+        "temp-file": "^3.3.3"
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+          "dev": true
         }
       }
     },
@@ -219,9 +254,9 @@
       "dev": true
     },
     "base64-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
-      "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
       "dev": true
     },
     "bcrypt-pbkdf": {
@@ -234,9 +269,9 @@
       }
     },
     "bindings": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
     },
     "bl": {
       "version": "1.2.2",
@@ -245,46 +280,76 @@
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "bluebird": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
     },
     "bluebird-lst": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.5.tgz",
-      "integrity": "sha512-Ey0bDNys5qpYPhZ/oQ9vOEvD0TYQDTILMXWP2iGfvMg7rSDde+oV4aQQgqRH+CvBFNz2BSDQnPGMUl6LKBUUQA==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.9.tgz",
+      "integrity": "sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==",
       "requires": {
-        "bluebird": "^3.5.1"
+        "bluebird": "^3.5.5"
       }
     },
     "boxen": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
+      "integrity": "sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==",
       "dev": true,
       "requires": {
-        "ansi-align": "^2.0.0",
-        "camelcase": "^4.0.0",
-        "chalk": "^2.0.1",
-        "cli-boxes": "^1.0.0",
-        "string-width": "^2.0.0",
+        "ansi-align": "^3.0.0",
+        "camelcase": "^5.3.1",
+        "chalk": "^2.4.2",
+        "cli-boxes": "^2.2.0",
+        "string-width": "^3.0.0",
         "term-size": "^1.2.0",
+        "type-fest": "^0.3.0",
         "widest-line": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -294,22 +359,23 @@
           "dev": true
         },
         "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
+            "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -349,64 +415,103 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "builder-util": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-6.1.3.tgz",
-      "integrity": "sha512-MXeARNff9KHlzJYGJcAhLI/tpE57PmUnleaYfL22IE+viRt192Yr3wQL444ztsA+LUHJ8d12moUoG00jh1hfLA==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-10.1.2.tgz",
+      "integrity": "sha512-LQMh36Cg0r4ZfKqNlaUclndS/IXxZ3OdCgmXvw1vdP3QwYT2NkyE7LfMikAFIHpXOs6zsVH+iW+Fe/AX1jfFag==",
       "dev": true,
       "requires": {
-        "7zip-bin": "~4.0.2",
-        "app-builder-bin": "2.1.2",
-        "bluebird-lst": "^1.0.5",
-        "builder-util-runtime": "^4.4.1",
-        "chalk": "^2.4.1",
-        "debug": "^3.1.0",
-        "fs-extra-p": "^4.6.1",
-        "is-ci": "^1.2.0",
-        "js-yaml": "^3.12.0",
-        "lazy-val": "^1.0.3",
-        "semver": "^5.5.1",
-        "source-map-support": "^0.5.9",
-        "stat-mode": "^0.2.2",
-        "temp-file": "^3.1.3"
+        "7zip-bin": "~4.1.0",
+        "@types/debug": "^4.1.4",
+        "app-builder-bin": "2.7.1",
+        "bluebird-lst": "^1.0.9",
+        "builder-util-runtime": "^8.2.5",
+        "chalk": "^2.4.2",
+        "debug": "^4.1.1",
+        "fs-extra-p": "^8.0.2",
+        "is-ci": "^2.0.0",
+        "js-yaml": "^3.13.1",
+        "source-map-support": "^0.5.12",
+        "stat-mode": "^0.3.0",
+        "temp-file": "^3.3.3"
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
     "builder-util-runtime": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-4.4.1.tgz",
-      "integrity": "sha512-8L2pbL6D3VdI1f8OMknlZJpw0c7KK15BRz3cY77AOUElc4XlCv2UhVV01jJM7+6Lx7henaQh80ALULp64eFYAQ==",
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.2.5.tgz",
+      "integrity": "sha512-YILT+YUlxrE3yNB6mDC1tF+Q24mr1LSYdjP5U861jbBeDZfvy1/VPDzW3boMVrDtzYnDnvkYrzLJnoh6TXA75w==",
+      "dev": true,
       "requires": {
-        "bluebird-lst": "^1.0.5",
-        "debug": "^3.1.0",
-        "fs-extra-p": "^4.6.1",
+        "bluebird-lst": "^1.0.9",
+        "debug": "^4.1.1",
+        "fs-extra-p": "^8.0.2",
         "sax": "^1.2.4"
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
+    "cacheable-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+      "dev": true,
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^3.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^1.0.2"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "lowercase-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+          "dev": true
+        }
+      }
     },
     "camelcase": {
       "version": "2.1.1",
@@ -424,21 +529,15 @@
         "map-obj": "^1.0.0"
       }
     },
-    "capture-stack-trace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
-      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
-      "dev": true
-    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
@@ -447,14 +546,14 @@
       }
     },
     "child-process-es6-promise": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/child-process-es6-promise/-/child-process-es6-promise-1.2.0.tgz",
-      "integrity": "sha512-15CDhq/RGyYjeAvezWjZQs4Mw/t5WNxO6+dw8w5xEs+C/w3htoUv0TWQBjO6MyTbIuom0LWNWS9xN7yD46j8sA=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/child-process-es6-promise/-/child-process-es6-promise-1.2.1.tgz",
+      "integrity": "sha512-ekKf2tD+2B2AZvLBhrBb44oelJSjeBkG3dZHpF5oIC9xhePhI3cAMqxyAxLMmskpc81GfCodSRh29wshnsOd/g=="
     },
     "chownr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
     },
     "chromium-pickle-js": {
       "version": "0.2.0",
@@ -463,15 +562,15 @@
       "dev": true
     },
     "ci-info": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.4.0.tgz",
-      "integrity": "sha512-Oqmw2pVfCl8sCL+1QgMywPfdxPJPkC51y4usw0iiE2S9qnEOAqXy8bwl1CpMpnoU39g4iKJTz6QZj+28FvOnjQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
     },
     "cli-boxes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
+      "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
       "dev": true
     },
     "clipboardy": {
@@ -483,20 +582,20 @@
       }
     },
     "cliui": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
       "dev": true,
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -506,24 +605,34 @@
           "dev": true
         },
         "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
+            "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
+      }
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
       }
     },
     "co": {
@@ -582,12 +691,44 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "conf": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/conf/-/conf-2.0.0.tgz",
-      "integrity": "sha512-iCLzBsGFi8S73EANsEJZz0JnJ/e5VZef/kSaxydYZLAvw0rFNAUx5R7K5leC/CXXR2mZfXWhUvcZOO/dM2D5xg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-2.2.0.tgz",
+      "integrity": "sha512-93Kz74FOMo6aWRVpAZsonOdl2I57jKtHrNmxhumehFQw4X8Sk37SohNY11PG7Q8Okta+UnrVaI006WLeyp8/XA==",
       "requires": {
         "dot-prop": "^4.1.0",
         "env-paths": "^1.0.0",
@@ -597,9 +738,9 @@
       }
     },
     "configstore": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
-      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
+      "integrity": "sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==",
       "dev": true,
       "requires": {
         "dot-prop": "^4.1.0",
@@ -615,13 +756,16 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "create-error-class": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "dev": true,
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "requires": {
-        "capture-stack-trace": "^1.0.0"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "crypto-random-string": {
@@ -675,23 +819,29 @@
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
+    "defer-to-connect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
+      "integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw==",
+      "dev": true
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "dmg-builder": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-5.3.1.tgz",
-      "integrity": "sha512-/+vtqlgvTtha/4Gc76XIRKS2KzYO58sTWXhZ/kgfNr05ZXY6bIw26v7xDu8ZBpTYnfWI09JRZTMv1yIXT/vvfg==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-6.7.2.tgz",
+      "integrity": "sha512-xfYOwhHjOSOIqkk8A0h8zcaio/WyzrAWpMTu9hzV3Z5PI4tOG0Pq6a9Lh/mHr1r3bydif8R21qGvKU1Re9CpUg==",
       "dev": true,
       "requires": {
-        "app-builder-lib": "~20.28.3",
-        "bluebird-lst": "^1.0.5",
-        "builder-util": "~6.1.3",
-        "fs-extra-p": "^4.6.1",
+        "app-builder-lib": "~20.44.4",
+        "bluebird-lst": "^1.0.9",
+        "builder-util": "~10.1.2",
+        "fs-extra-p": "^8.0.2",
         "iconv-lite": "^0.4.24",
-        "js-yaml": "^3.12.0",
+        "js-yaml": "^3.13.1",
         "parse-color": "^1.0.0",
         "sanitize-filename": "^1.6.1"
       }
@@ -705,9 +855,9 @@
       }
     },
     "dotenv": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.0.0.tgz",
-      "integrity": "sha512-FlWbnhgjtwD+uNLUGHbMykMOYQaTivdHEmYwAKFjn6GKe/CqY0fNae93ZHTd20snh9ZLr8mTzIL9m0APQ1pjQg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+      "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
       "dev": true
     },
     "dotenv-expand": {
@@ -733,49 +883,41 @@
       }
     },
     "ejs": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
-      "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.2.tgz",
+      "integrity": "sha512-PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q==",
       "dev": true
     },
     "electron": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.10.tgz",
-      "integrity": "sha512-J6A0AbOwDNl9f1K+P42uF8SKZ9MKzOSm21T9evkkwrMdGQsIm7vzmFZEYb5eFNdwv5x52tx8Q+IUeyg/LgYYxg==",
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.18.tgz",
+      "integrity": "sha512-PQRHtFvLxHdJzMMIwTddUtkS+Te/fZIs+PHO+zPmTUTBE76V3Od3WRGzMQwiJHxN679licmCKhJpMyxZfDEVWQ==",
       "dev": true,
       "requires": {
         "@types/node": "^8.0.24",
         "electron-download": "^3.0.1",
         "extract-zip": "^1.0.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "8.10.30",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.30.tgz",
-          "integrity": "sha512-Le8HGMI5gjFSBqcCuKP/wfHC19oURzkU2D+ERIescUoJd+CmNEMYBib9LQ4zj1HHEZOJQWhw2ZTnbD8weASh/Q==",
-          "dev": true
-        }
       }
     },
     "electron-builder": {
-      "version": "20.28.3",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-20.28.3.tgz",
-      "integrity": "sha512-Sbe7E18Fl88la642PpcMU4jxv/1/vI3PCT/+Szly3O97DtKwuuVmk5MhW+FDBKgNS2f0xJgA6vRRraDK6HYvrw==",
+      "version": "20.44.4",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-20.44.4.tgz",
+      "integrity": "sha512-H8zzP01albkKh2Ec1zc0A7RGriUkHb5M99NJskaYtgKtGATTAGH+r9OIWVk5Hk9c1dLMVudbqEeaSlygMF2asw==",
       "dev": true,
       "requires": {
-        "app-builder-lib": "20.28.3",
-        "bluebird-lst": "^1.0.5",
-        "builder-util": "6.1.3",
-        "builder-util-runtime": "4.4.1",
-        "chalk": "^2.4.1",
-        "dmg-builder": "5.3.1",
-        "fs-extra-p": "^4.6.1",
-        "is-ci": "^1.2.0",
-        "lazy-val": "^1.0.3",
-        "read-config-file": "3.1.2",
+        "app-builder-lib": "20.44.4",
+        "bluebird-lst": "^1.0.9",
+        "builder-util": "10.1.2",
+        "builder-util-runtime": "8.2.5",
+        "chalk": "^2.4.2",
+        "dmg-builder": "6.7.2",
+        "fs-extra-p": "^8.0.2",
+        "is-ci": "^2.0.0",
+        "lazy-val": "^1.0.4",
+        "read-config-file": "3.2.2",
         "sanitize-filename": "^1.6.1",
-        "update-notifier": "^2.5.0",
-        "yargs": "^12.0.1"
+        "update-notifier": "^3.0.0",
+        "yargs": "^13.2.4"
       }
     },
     "electron-download": {
@@ -795,12 +937,6 @@
         "sumchecker": "^1.2.0"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
         "path-exists": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
@@ -828,9 +964,9 @@
       "integrity": "sha512-v+Af5W5z99ehhaLOfE9eTSXUwjzh2wFlQjz51dvkZ6ZIrET6OB/zAZPvsuwT6tm3t5x+M1r+Ed3U3xtPZYAyuQ=="
     },
     "electron-osx-sign": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.10.tgz",
-      "integrity": "sha1-vk87ibKnWh3F8eckkIGrKSnKOiY=",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.11.tgz",
+      "integrity": "sha512-VVd40nrnVqymvFrY9ZkOYgHJOvexHHYTR3di/SN+mjJ0OWhR1I8BRVj3U+Yamw6hnkZZNKZp52rqL5EFAAPFkQ==",
       "dev": true,
       "requires": {
         "bluebird": "^3.5.0",
@@ -838,41 +974,33 @@
         "debug": "^2.6.8",
         "isbinaryfile": "^3.0.2",
         "minimist": "^1.2.0",
-        "plist": "^2.1.0"
+        "plist": "^3.0.1"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "plist": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz",
-          "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
+        "isbinaryfile": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
+          "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
           "dev": true,
           "requires": {
-            "base64-js": "1.2.0",
-            "xmlbuilder": "8.2.2",
-            "xmldom": "0.1.x"
+            "buffer-alloc": "^1.2.0"
           }
         }
       }
     },
     "electron-publish": {
-      "version": "20.28.3",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-20.28.3.tgz",
-      "integrity": "sha512-/2t5zk9EKgH7p7rFZ+ynTKLmpKGF9bktMP2UR6u4bbPz9w4r3WEUbPOeZ1TLqUCAqdfZECcj4ThjrlcAJTghCA==",
+      "version": "20.44.4",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-20.44.4.tgz",
+      "integrity": "sha512-50NzsKOnNqOpGJzPl04vMyitdguUvp15FWKWtu4KISsHfgdLMWGgxHGZwfMphc/vf364zXvPHsYQza3MASgaEQ==",
       "dev": true,
       "requires": {
-        "bluebird-lst": "^1.0.5",
-        "builder-util": "~6.1.3",
-        "builder-util-runtime": "^4.4.1",
-        "chalk": "^2.4.1",
-        "fs-extra-p": "^4.6.1",
-        "lazy-val": "^1.0.3",
-        "mime": "^2.3.1"
+        "bluebird-lst": "^1.0.9",
+        "builder-util": "~10.1.2",
+        "builder-util-runtime": "^8.2.5",
+        "chalk": "^2.4.2",
+        "fs-extra-p": "^8.0.2",
+        "lazy-val": "^1.0.4",
+        "mime": "^2.4.4"
       }
     },
     "electron-store": {
@@ -884,19 +1012,73 @@
       }
     },
     "electron-updater": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-3.1.2.tgz",
-      "integrity": "sha512-y3n37O01pdynMJHhJbOd2UVhVrmDW6zLvR2SOZ+gk3S6r16872+0nNbC48GXWwc26lTeus/Zja/XUpiqrvdw4A==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-3.2.3.tgz",
+      "integrity": "sha512-QkLS+hYyTTHzZ2gGtTyQQ3kY5zQaEf/VwJW+UP37CPi58/VNUOx0xNA9iChwwYa6mzeEyo1xhrS1XjePwkeTbA==",
       "requires": {
-        "bluebird-lst": "^1.0.5",
-        "builder-util-runtime": "~4.4.1",
+        "bluebird-lst": "^1.0.6",
+        "builder-util-runtime": "~7.1.0",
         "electron-is-dev": "^0.3.0",
-        "fs-extra-p": "^4.6.1",
+        "fs-extra-p": "^7.0.0",
         "js-yaml": "^3.12.0",
         "lazy-val": "^1.0.3",
         "lodash.isequal": "^4.5.0",
-        "semver": "^5.5.1",
+        "pako": "^1.0.6",
+        "semver": "^5.6.0",
         "source-map-support": "^0.5.9"
+      },
+      "dependencies": {
+        "builder-util-runtime": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-7.1.0.tgz",
+          "integrity": "sha512-TAsx651+q6bXYry21SzQblYQBUlfu4ixbDa6k2Nvts+kHO9ajyr0gDuHJsamxBaAyUUi5EldPABqsFERDEK3Hg==",
+          "requires": {
+            "bluebird-lst": "^1.0.6",
+            "debug": "^4.1.0",
+            "fs-extra-p": "^7.0.0",
+            "sax": "^1.2.4"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "fs-extra-p": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-7.0.1.tgz",
+          "integrity": "sha512-yhd2OV0HnHt2oitlp+X9hl2ReX4X/7kQeL7/72qzPHTZj5eUPGzAKOvEglU02Fa1OeG2rSy/aKB4WGVaLiF8tw==",
+          "requires": {
+            "bluebird-lst": "^1.0.7",
+            "fs-extra": "^7.0.1"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "electron-window-manager": {
@@ -908,6 +1090,12 @@
         "melanke-watchjs": "^1.3.1",
         "underscore": "^1.8.3"
       }
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -932,9 +1120,9 @@
       }
     },
     "es6-promise": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
       "dev": true
     },
     "escape-string-regexp": {
@@ -960,20 +1148,6 @@
         "p-finally": "^1.0.0",
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        }
       }
     },
     "extend": {
@@ -1018,23 +1192,21 @@
       }
     },
     "ffi": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ffi/-/ffi-2.2.0.tgz",
-      "integrity": "sha1-vxiwRmain3EiftVoldVDCvRwQvo=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ffi/-/ffi-2.3.0.tgz",
+      "integrity": "sha512-vkPA9Hf9CVuQ5HeMZykYvrZF2QNJ/iKGLkyDkisBnoOOFeFXZQhUPxBARPBIZMJVulvBI2R+jgofW03gyPpJcQ==",
       "requires": {
         "bindings": "~1.2.0",
         "debug": "2",
         "nan": "2",
         "ref": "1",
         "ref-struct": "1"
-      },
-      "dependencies": {
-        "bindings": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-          "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
-        }
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "find-up": {
       "version": "2.1.0",
@@ -1078,28 +1250,37 @@
       }
     },
     "fs-extra-p": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-4.6.1.tgz",
-      "integrity": "sha512-IsTMbUS0svZKZTvqF4vDS9c/L7Mw9n8nZQWWeSzAGacOSe+8CzowhUN0tdZEZFIJNP5HC7L9j3MMikz/G4hDeQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-8.1.0.tgz",
+      "integrity": "sha512-sCLpU5kk5CvrWZvFM9dUlqPgHrE02AEt6XYzF7kDscr5COc7DHfhNfODTXt0bkVNmt5DkvU2uJSYjorxY3bRKA==",
+      "dev": true,
       "requires": {
-        "bluebird-lst": "^1.0.5",
-        "fs-extra": "^6.0.1"
+        "bluebird-lst": "^1.0.9",
+        "fs-extra": "^8.1.0"
       },
       "dependencies": {
         "fs-extra": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
-          "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
+            "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
           }
+        },
+        "graceful-fs": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+          "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+          "dev": true
         },
         "jsonfile": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
           }
@@ -1113,9 +1294,9 @@
       "dev": true
     },
     "get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
     "get-stdin": {
@@ -1138,9 +1319,9 @@
       }
     },
     "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -1161,22 +1342,33 @@
       }
     },
     "got": {
-      "version": "6.7.1",
-      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
-      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
       "dev": true,
       "requires": {
-        "create-error-class": "^3.0.0",
+        "@sindresorhus/is": "^0.14.0",
+        "@szmarczak/http-timer": "^1.1.2",
+        "cacheable-request": "^6.0.0",
+        "decompress-response": "^3.3.0",
         "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "safe-buffer": "^5.0.1",
-        "timed-out": "^4.0.0",
-        "unzip-response": "^2.0.1",
-        "url-parse-lax": "^1.0.0"
+        "get-stream": "^4.1.0",
+        "lowercase-keys": "^1.0.1",
+        "mimic-response": "^1.0.1",
+        "p-cancelable": "^1.0.0",
+        "to-readable-stream": "^1.0.0",
+        "url-parse-lax": "^3.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
       }
     },
     "graceful-fs": {
@@ -1204,6 +1396,12 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-yarn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+      "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
+      "dev": true
+    },
     "home-path": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.6.tgz",
@@ -1214,6 +1412,17 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
+    },
+    "html-entities": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+    },
+    "http-cache-semantics": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
+      "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==",
       "dev": true
     },
     "http-signature": {
@@ -1227,11 +1436,12 @@
       }
     },
     "iconv": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/iconv/-/iconv-2.3.0.tgz",
-      "integrity": "sha512-eu9senpOZ7wzNweLX09jtrCdmEiie8Z5/iMxdIq3i7tkgg562EwKSU9yjXMz8ncaQ0B+845vbqAz+1kPFXzbtQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/iconv/-/iconv-2.3.4.tgz",
+      "integrity": "sha512-v2Rree7xRtrC9o3Bi9nTNOKXvApmwLFdX50k72+K1W4mJ93LBdpaLcHcInYo9gr/GcQk8MFoCetrYRcb/o3RLg==",
       "requires": {
-        "nan": "^2.3.5"
+        "nan": "^2.13.1",
+        "safer-buffer": "^2.1.2"
       }
     },
     "iconv-lite": {
@@ -1274,9 +1484,9 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.5",
@@ -1285,23 +1495,47 @@
       "dev": true
     },
     "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
       "dev": true
     },
     "iohook": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/iohook/-/iohook-0.2.0.tgz",
-      "integrity": "sha512-P6dqN69pSzDR0TTjgytE1yhTYGr0mRvpP2wf+WnfGd6dclxSxEoMYC8uCrOZW7T8JOzhr+RoNIJdJVhlB+edbw==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/iohook/-/iohook-0.2.6.tgz",
+      "integrity": "sha512-gE+5i+0pdW+AxjAKHg7h423wmT64bokAHMuD9hKSmku8kknAwmSEBsAxr4HkGXy9IiL51CzVAthewBxc8pdp2w==",
       "requires": {
         "@types/node": "^7.0.62",
         "bindings": "^1.3.0",
         "node-abi": "^2.4.0",
         "pump": "^1.0.3",
-        "segfault-handler": "^1.0.0",
+        "segfault-handler": "^1.0.1",
         "simple-get": "^2.8.1",
         "tar-fs": "^1.16.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "7.10.6",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.6.tgz",
+          "integrity": "sha512-d0BOAicT0tEdbdVQlLGOVul1kvg6YvbaADRCThGCz5NJ0e9r00SofcR1x69hmlCyrHuB6jd4cKzL9bMLjPnpAA=="
+        },
+        "bindings": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+          "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+          "requires": {
+            "file-uri-to-path": "1.0.0"
+          }
+        },
+        "pump": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
       }
     },
     "is-arrayish": {
@@ -1310,22 +1544,13 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "^1.0.0"
-      }
-    },
     "is-ci": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.0.tgz",
-      "integrity": "sha512-plgvKjQtalH2P3Gytb7L61Lmz95g2DlpzFiQyRSFew8WoJKxtKRzrZMeyRN2supblm3Psc8OQGy7Xjb6XG11jw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "dev": true,
       "requires": {
-        "ci-info": "^1.3.0"
+        "ci-info": "^2.0.0"
       }
     },
     "is-finite": {
@@ -1357,9 +1582,9 @@
       }
     },
     "is-npm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-3.0.0.tgz",
+      "integrity": "sha512-wsigDr1Kkschp2opC4G3yA6r9EgVA6NjRpWzIi9axXqeIaAATPRJc4uLujXe3Nd9uO8KoDyA4MD6aZSeXTADhA==",
       "dev": true
     },
     "is-obj": {
@@ -1375,18 +1600,6 @@
       "requires": {
         "path-is-inside": "^1.0.1"
       }
-    },
-    "is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-      "dev": true
-    },
-    "is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -1404,19 +1617,23 @@
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
+    "is-yarn-global": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+      "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
+      "dev": true
+    },
     "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
     },
     "isbinaryfile": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
-      "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
-      "dev": true,
-      "requires": {
-        "buffer-alloc": "^1.2.0"
-      }
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.1.tgz",
+      "integrity": "sha512-bvJxbNWm72dy/1+qeBm9F8wUM4siDnlzid7NN5Ib4nQcc0tNIx/YWgEih1ZRHXr8xVbpGk1ccLlA9gOSlyx3gw==",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -1429,19 +1646,19 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jquery": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
     "js-base64": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.9.tgz",
-      "integrity": "sha512-xcinL3AuDJk7VSzsHgb9DvvIXayBbadtMZ4HFPx8rUszbW1MuNMlwYVC4zzCZ6e1sqZpnNS5ZFYOhXqA39T7LQ=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
+      "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -1452,6 +1669,12 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
+    },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -1469,20 +1692,12 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+      "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "jsonfile": {
@@ -1505,6 +1720,15 @@
         "verror": "1.10.0"
       }
     },
+    "keyv": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.0"
+      }
+    },
     "klaw": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
@@ -1515,26 +1739,26 @@
       }
     },
     "latest-version": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+      "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
       "dev": true,
       "requires": {
-        "package-json": "^4.0.0"
+        "package-json": "^6.3.0"
       }
     },
     "lazy-val": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.3.tgz",
-      "integrity": "sha512-pjCf3BYk+uv3ZcPzEVM0BFvO9Uw58TmlrU0oG5tTrr9Kcid3+kdKxapH8CjdYmVa2nO5wOoZn2rdvZx2PKj/xg=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.4.tgz",
+      "integrity": "sha512-u93kb2fPbIrfzBuLjZE+w+fJbUUMhNDXxNmMfaqNgpfQf1CO5ZSe2LfsnBqVAk7i/2NF48OSoRj+Xe2VT+lE8Q=="
     },
     "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
       "dev": true,
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "^2.0.0"
       }
     },
     "load-json-file": {
@@ -1568,9 +1792,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.isequal": {
       "version": "4.5.0",
@@ -1594,9 +1818,9 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "requires": {
         "pseudomap": "^1.0.2",
@@ -1611,6 +1835,15 @@
         "pify": "^3.0.0"
       }
     },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
     "map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
@@ -1623,12 +1856,14 @@
       "integrity": "sha512-YUQzBucdH5p3s/UPQ0fvYyzqRfyLKTS35Qj5iaVBQ6XYGvvpEX7afR1xi8uUGsTEfFNqDFRrADz9TkVu4/TeXQ=="
     },
     "mem": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
       }
     },
     "meow": {
@@ -1647,20 +1882,12 @@
         "read-pkg-up": "^1.0.1",
         "redent": "^1.0.0",
         "trim-newlines": "^1.0.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "mime": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
-      "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
       "dev": true
     },
     "mime-db": {
@@ -1677,9 +1904,9 @@
       }
     },
     "mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
     "mimic-response": {
@@ -1697,9 +1924,10 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -1707,6 +1935,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
       }
     },
     "ms": {
@@ -1715,9 +1950,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nan": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -1725,24 +1960,30 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node-abi": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.3.tgz",
-      "integrity": "sha512-b656V5C0628gOOA2kwcpNA/bxdlqYF9FvxJ+qqVX0ctdXNVZpS8J6xEUYir3WAKc7U0BH/NRlSpNbGsy+azjeg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.9.0.tgz",
+      "integrity": "sha512-jmEOvv0eanWjhX8dX1pmjb7oJl1U1oR4FOh0b2GnvALwSYoOdU7sj+kLDSAyjo4pfC9aj/IxkloxdLJQhSSQBA==",
       "requires": {
         "semver": "^5.4.1"
       }
     },
     "normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
+        "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
       }
+    },
+    "normalize-url": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
+      "integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
+      "dev": true
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -1765,14 +2006,6 @@
         "request": "^2.45.0",
         "single-line-log": "^1.1.2",
         "throttleit": "0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "number-is-nan": {
@@ -1812,48 +2045,64 @@
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
       "dev": true,
       "requires": {
-        "execa": "^0.7.0",
-        "lcid": "^1.0.0",
-        "mem": "^1.1.0"
+        "execa": "^1.0.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
       },
       "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
         "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
             "is-stream": "^1.1.0",
             "npm-run-path": "^2.0.0",
             "p-finally": "^1.0.0",
             "signal-exit": "^3.0.0",
             "strip-eof": "^1.0.0"
           }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
         }
       }
+    },
+    "p-cancelable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+      "dev": true
+    },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+      "dev": true
     },
     "p-limit": {
       "version": "1.3.0",
@@ -1877,16 +2126,29 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "package-json": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.4.0.tgz",
+      "integrity": "sha512-bd1T8OBG7hcvMd9c/udgv6u5v9wISP3Oyl9Cm7Weop8EFwrtcQDnS2sb6zhwqus2WslSr5wSTIPiTTpxxmPm7Q==",
       "dev": true,
       "requires": {
-        "got": "^6.7.1",
-        "registry-auth-token": "^3.0.1",
-        "registry-url": "^3.0.3",
-        "semver": "^5.1.0"
+        "got": "^9.6.0",
+        "registry-auth-token": "^3.4.0",
+        "registry-url": "^5.0.0",
+        "semver": "^6.1.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+          "dev": true
+        }
       }
+    },
+    "pako": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+      "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw=="
     },
     "parse-color": {
       "version": "1.0.0",
@@ -1935,6 +2197,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
     },
     "path-type": {
       "version": "1.1.0",
@@ -2003,20 +2271,6 @@
         "base64-js": "^1.2.3",
         "xmlbuilder": "^9.0.7",
         "xmldom": "0.1.x"
-      },
-      "dependencies": {
-        "base64-js": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-          "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-          "dev": true
-        },
-        "xmlbuilder": {
-          "version": "9.0.7",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-          "dev": true
-        }
       }
     },
     "poe-ninja-api-manager": {
@@ -2030,9 +2284,9 @@
       }
     },
     "prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
       "dev": true
     },
     "pretty-bytes": {
@@ -2046,9 +2300,9 @@
       }
     },
     "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress-stream": {
       "version": "1.2.0",
@@ -2080,9 +2334,10 @@
       "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
     },
     "pump": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -2108,37 +2363,29 @@
         "ini": "~1.3.0",
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "read-config-file": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-3.1.2.tgz",
-      "integrity": "sha512-QCATYzlYHvmWps/W/eP7rcKuhYRYZg5XKeXFxSJRIXvn+KSw1+Ntz2et1aBz5TrEpawGrxWZ7zBipj+/v0xwWQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-3.2.2.tgz",
+      "integrity": "sha512-PuFpMgZF01VB0ydH1dfitAxCP/fh+qnfbA9cYNIPoxPbz0SMngsrafCtaHDWfER7MwlDz4fmrNBhPkakxxFpTg==",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.2",
-        "ajv-keywords": "^3.2.0",
-        "bluebird-lst": "^1.0.5",
-        "dotenv": "^6.0.0",
+        "ajv": "^6.9.2",
+        "ajv-keywords": "^3.4.0",
+        "bluebird-lst": "^1.0.7",
+        "dotenv": "^6.2.0",
         "dotenv-expand": "^4.2.0",
-        "fs-extra-p": "^4.6.1",
-        "js-yaml": "^3.12.0",
-        "json5": "^1.0.1",
-        "lazy-val": "^1.0.3"
+        "fs-extra-p": "^7.0.1",
+        "js-yaml": "^3.12.1",
+        "json5": "^2.1.0",
+        "lazy-val": "^1.0.4"
       },
       "dependencies": {
         "ajv": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
-          "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+          "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",
@@ -2153,11 +2400,41 @@
           "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
           "dev": true
         },
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "fs-extra-p": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-7.0.1.tgz",
+          "integrity": "sha512-yhd2OV0HnHt2oitlp+X9hl2ReX4X/7kQeL7/72qzPHTZj5eUPGzAKOvEglU02Fa1OeG2rSy/aKB4WGVaLiF8tw==",
+          "dev": true,
+          "requires": {
+            "bluebird-lst": "^1.0.7",
+            "fs-extra": "^7.0.1"
+          }
+        },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
         }
       }
     },
@@ -2204,17 +2481,15 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
       }
     },
     "redent": {
@@ -2257,9 +2532,9 @@
       }
     },
     "registry-auth-token": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
-      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+      "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
       "dev": true,
       "requires": {
         "rc": "^1.1.6",
@@ -2267,12 +2542,12 @@
       }
     },
     "registry-url": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
       "dev": true,
       "requires": {
-        "rc": "^1.0.1"
+        "rc": "^1.2.8"
       }
     },
     "repeating": {
@@ -2312,21 +2587,21 @@
       }
     },
     "request-promise-core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
       "requires": {
-        "lodash": "^4.13.1"
+        "lodash": "^4.17.11"
       }
     },
     "request-promise-native": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+      "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
       "requires": {
-        "request-promise-core": "1.1.1",
-        "stealthy-require": "^1.1.0",
-        "tough-cookie": ">=2.3.3"
+        "request-promise-core": "1.1.2",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
       }
     },
     "require-directory": {
@@ -2336,18 +2611,36 @@
       "dev": true
     },
     "require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
-    "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+    "resolve": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "path-parse": "^1.0.6"
+      }
+    },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "^1.0.0"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
       }
     },
     "safe-buffer": {
@@ -2375,18 +2668,18 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "segfault-handler": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/segfault-handler/-/segfault-handler-1.0.1.tgz",
-      "integrity": "sha512-3koBV3F0IPxTYacnoL7WoFlaMndXsXj62tiVbbW9Kzp3K+F9Y6GWW5XmKSv7j+7nf2M+qjNzc4W1iZoa8vocjw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/segfault-handler/-/segfault-handler-1.3.0.tgz",
+      "integrity": "sha512-p7kVHo+4uoYkr0jmIiTBthwV5L2qmWtben/KDunDZ834mbos+tY+iO0//HpAJpOFSQZZ+wxKWuRo4DxV02B7Lg==",
       "requires": {
         "bindings": "^1.2.1",
-        "nan": "^2.0.9"
+        "nan": "^2.14.0"
       }
     },
     "semver": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -2451,18 +2744,18 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-support": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-      "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+      "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
     },
     "spdx-correct": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -2470,9 +2763,9 @@
       }
     },
     "spdx-exceptions": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
       "dev": true
     },
     "spdx-expression-parse": {
@@ -2486,9 +2779,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
       "dev": true
     },
     "speedometer": {
@@ -2519,9 +2812,9 @@
       }
     },
     "stat-mode": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
-      "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.3.0.tgz",
+      "integrity": "sha512-QjMLR0A3WwFY2aZdV0okfFEJB5TRjkggXZjxP3A1RsWsNHNu3YPv8btmtc6iCFZ0Rul3FE93OYogvhOUClU+ng==",
       "dev": true
     },
     "stealthy-require": {
@@ -2541,12 +2834,10 @@
       }
     },
     "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -2614,32 +2905,76 @@
         "mkdirp": "^0.5.1",
         "pump": "^1.0.0",
         "tar-stream": "^1.1.2"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
       }
     },
     "tar-stream": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
-      "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
       "requires": {
         "bl": "^1.0.0",
-        "buffer-alloc": "^1.1.0",
+        "buffer-alloc": "^1.2.0",
         "end-of-stream": "^1.0.0",
         "fs-constants": "^1.0.0",
         "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.0",
+        "to-buffer": "^1.1.1",
         "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+        }
       }
     },
     "temp-file": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.1.3.tgz",
-      "integrity": "sha512-oz2J77loDE9sGrlRTqBzwbsUvoBD2BpyXeaRPKyGwBIwaamSs2jdqAfhutw7Tch9llr1u8E2ruoug09rNPa3PA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.3.3.tgz",
+      "integrity": "sha512-ErWJ0vfZwkozaH7dn/5QtYdrGwy6fWID0GG3PEzNb9Vmt6urL4mQ3lKz7NWVi1/kmZsWQzgjTL7/P4mwGx5jqg==",
       "dev": true,
       "requires": {
         "async-exit-hook": "^2.0.1",
-        "bluebird-lst": "^1.0.5",
-        "fs-extra-p": "^4.6.1",
-        "lazy-val": "^1.0.3"
+        "bluebird-lst": "^1.0.9",
+        "fs-extra-p": "^8.0.2"
       }
     },
     "term-size": {
@@ -2693,53 +3028,18 @@
       "requires": {
         "readable-stream": "~1.1.9",
         "xtend": "~2.1.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "dev": true,
-          "requires": {
-            "object-keys": "~0.4.0"
-          }
-        }
       }
-    },
-    "timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-      "dev": true
     },
     "to-buffer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
       "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+    },
+    "to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+      "dev": true
     },
     "tough-cookie": {
       "version": "2.4.3",
@@ -2779,6 +3079,12 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
     },
+    "type-fest": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+      "dev": true
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -2804,26 +3110,22 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
-    "unzip-response": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-      "dev": true
-    },
     "update-notifier": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
-      "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-3.0.1.tgz",
+      "integrity": "sha512-grrmrB6Zb8DUiyDIaeRTBCkgISYUgETNe7NglEbVsrLWXeESnlCSP50WfRSj/GmzMPl6Uchj24S/p80nP/ZQrQ==",
       "dev": true,
       "requires": {
-        "boxen": "^1.2.1",
+        "boxen": "^3.0.0",
         "chalk": "^2.0.1",
-        "configstore": "^3.0.0",
+        "configstore": "^4.0.0",
+        "has-yarn": "^2.1.0",
         "import-lazy": "^2.1.0",
-        "is-ci": "^1.0.10",
+        "is-ci": "^2.0.0",
         "is-installed-globally": "^0.1.0",
-        "is-npm": "^1.0.0",
-        "latest-version": "^3.0.0",
+        "is-npm": "^3.0.0",
+        "is-yarn-global": "^0.3.0",
+        "latest-version": "^5.0.0",
         "semver-diff": "^2.0.0",
         "xdg-basedir": "^3.0.0"
       }
@@ -2846,12 +3148,12 @@
       }
     },
     "url-parse-lax": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
       "dev": true,
       "requires": {
-        "prepend-http": "^1.0.1"
+        "prepend-http": "^2.0.0"
       }
     },
     "utf8-byte-length": {
@@ -2905,9 +3207,9 @@
       "dev": true
     },
     "widest-line": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
-      "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
       "dev": true,
       "requires": {
         "string-width": "^2.1.1"
@@ -2947,13 +3249,48 @@
       }
     },
     "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "wrappy": {
@@ -3001,9 +3338,9 @@
       "dev": true
     },
     "xmlbuilder": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
-      "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
       "dev": true
     },
     "xmldom": {
@@ -3012,16 +3349,14 @@
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
       "dev": true
     },
-    "xregexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
-      "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==",
-      "dev": true
-    },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+      "dev": true,
+      "requires": {
+        "object-keys": "~0.4.0"
+      }
     },
     "y18n": {
       "version": "4.0.0",
@@ -3036,39 +3371,29 @@
       "dev": true
     },
     "yargs": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz",
-      "integrity": "sha512-B0vRAp1hRX4jgIOWFtjfNjd9OA9RWYZ6tqGA9/I/IrTMsxmKvtWy+ersM+jzpQqbC3YfLzeABPdeTgcJ9eu1qQ==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
+      "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
       "dev": true,
       "requires": {
-        "cliui": "^4.0.0",
-        "decamelize": "^2.0.0",
+        "cliui": "^5.0.0",
         "find-up": "^3.0.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^2.0.0",
+        "get-caller-file": "^2.0.1",
+        "os-locale": "^3.1.0",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
+        "require-main-filename": "^2.0.0",
         "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
+        "string-width": "^3.0.0",
         "which-module": "^2.0.0",
-        "y18n": "^3.2.1 || ^4.0.0",
-        "yargs-parser": "^10.1.0"
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
-        },
-        "decamelize": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
-          "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
-          "dev": true,
-          "requires": {
-            "xregexp": "4.0.0"
-          }
         },
         "find-up": {
           "version": "3.0.0",
@@ -3096,9 +3421,9 @@
           }
         },
         "p-limit": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -3114,45 +3439,47 @@
           }
         },
         "p-try": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
         },
         "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
+            "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
     },
     "yargs-parser": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-      "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
       "dev": true,
       "requires": {
-        "camelcase": "^4.1.0"
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
       },
       "dependencies": {
         "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
           "dev": true
         }
       }
@@ -3165,6 +3492,11 @@
       "requires": {
         "fd-slicer": "~1.0.1"
       }
+    },
+    "zlib": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/zlib/-/zlib-1.0.5.tgz",
+      "integrity": "sha1-bnyXL8NxxkWmr7A6sUdp3vEU/MA="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,24 +34,26 @@
   },
   "license": "MIT",
   "dependencies": {
-    "active-win": "^3.0.0",
-    "child-process-es6-promise": "^1.2.0",
+    "active-win": "^3.0.1",
+    "child-process-es6-promise": "^1.2.1",
     "clipboardy": "github:klayveR/clipboardy",
     "electron-is-dev": "^0.3.0",
     "electron-log": "^2.2.17",
     "electron-store": "^2.0.0",
-    "electron-updater": "^3.1.2",
+    "electron-updater": "^3.2.3",
     "electron-window-manager": "^1.0.6",
     "ffi": "^2.2.0",
-    "iohook": "^0.2.0",
-    "jquery": "^3.3.1",
-    "js-base64": "^2.4.9",
+    "html-entities": "^1.2.1",
+    "iohook": "^0.2.6",
+    "jquery": "^3.4.1",
+    "js-base64": "^2.5.1",
     "poe-ninja-api-manager": "^0.7.0",
     "promise-fs": "^1.3.0",
-    "request-promise-native": "^1.0.5",
+    "request-promise-native": "^1.0.7",
     "underscore": "^1.9.1",
     "x11": "^2.3.0",
-    "x11-prop": "^0.4.3"
+    "x11-prop": "^0.4.3",
+    "zlib": "^1.0.5"
   },
   "cmake-js": {
     "runtime": "electron",
@@ -100,7 +102,7 @@
     }
   },
   "devDependencies": {
-    "electron": "^2.0.10",
-    "electron-builder": "^20.28.3"
+    "electron": "^2.0.18",
+    "electron-builder": "^20.44.4"
   }
 }

--- a/src/css/settings.css
+++ b/src/css/settings.css
@@ -171,6 +171,11 @@ i {
   font-size: 13px;
 }
 
+.content .note {
+  color: #748199;
+  font-size: 13px;
+}
+
 .content .option label.wrap {
   margin: 5px 0px;
   width: 100%;
@@ -205,4 +210,24 @@ i {
   z-index: 1;
   width: 20px;
   pointer-events: none;
+}
+
+.content .option  a {
+  color: #748199;
+}
+
+.content .option  input {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+  background: #303a4c;
+  color: #FFFFFF;
+  padding: 7px;
+  font-size: 11px;
+  border: 0;
+  width: 100%;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  cursor: pointer;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ const log = require('electron-log');
 const Config = require("electron-store");
 const Helpers = require("./modules/helpers.js");
 const NinjaAPI = require("poe-ninja-api-manager");
+const PoeData = require("./modules/poedata.js");
 const Templates = require("./modules/templates.js");
 const Pricecheck = require("./modules/pricecheck.js");
 const AutoMinimize = require("./modules/auto-minimize.js");
@@ -23,6 +24,7 @@ const GUI = require("./modules/gui/gui.js");
 global.config = Helpers.createConfig();
 global.templates = new Templates();
 global.ninjaAPI = new NinjaAPI();
+global.poeData = new PoeData();
 global.entries = {};
 
 class XenonTrade {
@@ -54,6 +56,9 @@ class XenonTrade {
       // Check dependencies and update poe.ninja
       this.checkDependencies();
       Pricecheck.updateNinja();
+      if (config.get("poeDataInterval") > 0) {
+        poeData.update();
+      }
       return;
     })
     .catch((error) => {

--- a/src/modules/entries/poe-trade-entry.js
+++ b/src/modules/entries/poe-trade-entry.js
@@ -1,0 +1,73 @@
+const PriceCheckEntry = require("./pricecheck-entry.js");
+const CurrencyIcons = require("../../resource/icons/currencyIcons");
+const BaseTypeIcons = require("../../resource/icons/baseTypeIcons");
+
+class PoeTradeEntry extends PriceCheckEntry {
+  /**
+  * Creates a new RareItemEntry object
+  *
+  * @constructor
+  * @param {Object} poePrices poeprices.info result, including item text in base 64
+  * @param {Parser} parser Parser object
+  */
+  constructor(poePrices, parser) {
+    super();
+    this.poePrices = poePrices;
+    this.parser = parser;
+  }
+
+  add() {
+    var template = templates.get("poeTrade.html");
+    var replacements = this._buildReplacements();
+
+    // Set template, replacements and add
+    super.setTemplate(template);
+    super.setReplacements(replacements);
+    super.add();
+
+    // Set buttons, links, prediction explanation and feedback elements
+    super.setCloseable(true);
+    super.enableExternalLinks();
+
+    // Enable autoclose if configured
+    if(config.get("autoclose.enabled") && config.get("autoclose.timeouts.rare.enabled")) {
+      if(!(config.get("autoclose.threshold.enabled")
+        && (this.poePrices.price.min > config.get("autoclose.threshold.value") || this.poePrices.price.currency === "exalt"))) {
+        super.enableAutoClose(config.get("autoclose.timeouts.rare.value"));
+      }
+    }
+  }
+
+  _buildReplacements() {
+    var baseType = this.parser.getBaseType();
+    var url = this.poePrices.searchUrl;
+    var currencyIcon = "", currencyName = "";
+
+    if(this.poePrices.price.currency === "chaos") {
+      currencyName = "Chaos Orb";
+    } else {
+      currencyName = "Exalted Orb";
+    }
+
+    currencyIcon = CurrencyIcons[currencyName];
+
+    var replacements = [
+      { find: "item-name", replace: this.parser.getName() },
+      { find: "item-baseType", replace: baseType },
+      { find: "item-value-min", replace: this.poePrices.price.min },
+      { find: "item-value-max", replace: this.poePrices.price.max },
+      { find: "currency-name", replace: currencyName },
+      { find: "currency-icon", replace: currencyIcon },
+      { find: "link", replace: url}
+    ];
+
+    if(BaseTypeIcons.hasOwnProperty(baseType)) {
+      replacements.push({ find: "item-icon", replace: BaseTypeIcons[baseType] });
+    }
+
+    return replacements;
+  }
+
+}
+
+module.exports = PoeTradeEntry;

--- a/src/modules/entry.js
+++ b/src/modules/entry.js
@@ -160,6 +160,7 @@ class Entry {
   add() {
     if(!this.added) {
       this.added = true;
+      
       var template = this._getReplacedTemplate(this.template, this.replacements, "%");
 
       // If no entries available, set whole content of div, otherwise append

--- a/src/modules/gui/gui.js
+++ b/src/modules/gui/gui.js
@@ -50,6 +50,13 @@ class GUI {
       Pricecheck.updateNinja();
     });
 
+    // Update PoeData when the the according provider is selected in the settings
+    windowManager.bridge.on('provider-change', function(event) {
+      if (event.provider == "poetrade") {
+        poeData.update();
+      }
+    });
+
     // Adjust window size based on scale factor when it's changed
     windowManager.bridge.on('zoomfactor-change', function(event) {
       GUI.setZoomFactor(event.value);
@@ -190,7 +197,7 @@ class GUI {
   * Toggles a menu buttons icon color
   */
   static toggleMenuButtonColor(button, state) {
-    var button = $("[data-button='" + button + "']").find("i");
+    button = $("[data-button='" + button + "']").find("i");
 
     if(typeof state === "undefined") {
       button.toggleClass("grey");

--- a/src/modules/gui/settings.js
+++ b/src/modules/gui/settings.js
@@ -46,6 +46,7 @@ class SettingsGUI {
     settingsWindow.object.on("show", function() {
       windowManager.bridge.emit('show', {'window': SettingsGUI.NAME});
     });
+
   }
 
   /**
@@ -58,6 +59,9 @@ class SettingsGUI {
     SettingsGUI._initializeSliders();
     SettingsGUI._initializeVersionNumber();
     SettingsGUI._initializeNavigation();
+    SettingsGUI._initializeLinks();
+    SettingsGUI._initializeProviders();
+    SettingsGUI._initializePoeDataSettings();
   }
 
   /**
@@ -97,6 +101,13 @@ class SettingsGUI {
 
     $(".settings").find("[data-slider]").each(function (index, element) {
       SettingsGUI._initializeSlider($(this));
+    });
+  }
+  static _initializeLinks() {
+    // Open external links in the browser by default
+    $(document).on('click', 'a[href^="http"]', function(event) {
+        event.preventDefault();
+        electron.shell.openExternal(this.href);
     });
   }
 
@@ -252,6 +263,46 @@ class SettingsGUI {
   }
 
   /**
+  * Initializes price provider settings
+  */
+  static _initializeProviders() {
+    // Select option change listener
+    $("#providerRareSelect").val(config.get("provider_rare")).change(function() {
+      var provider = $("#providerRareSelect").val();
+      SettingsGUI.changePriceProvider("rare", provider);
+    });
+    // Select option change listener
+    $("#providerCurrencySelect").val(config.get("provider_currency")).change(function() {
+      var provider = $("#providerCurrencySelect").val();
+      SettingsGUI.changePriceProvider("currency", provider);
+    });
+    // Select option change listener
+    $("#providerOthersSelect").val(config.get("provider_others")).change(function() {
+      var provider = $("#providerOthersSelect").val();
+      SettingsGUI.changePriceProvider("others", provider);
+    });
+  }
+
+  /**
+  * Initializes league settings
+  *
+  * @param {Array} leagues Array of leagues
+  */
+  static _initializePoeDataSettings() {
+    // Poe-Data config
+    $("#poeDataLoginOption input").val(config.get("poeDataLogin")).keyup(function() {
+      SettingsGUI.changePoeDataLogin( $(this).val() );
+    }).change(function() {
+      SettingsGUI.changePoeDataLogin( $(this).val() );
+    });
+    $("#poeDataPasswordOption input").val(config.get("poeDataPassword")).keyup(function() {
+      SettingsGUI.changePoeDataPass( $(this).val() );
+    }).change(function() {
+      SettingsGUI.changePoeDataPass( $(this).val() );
+    });
+  }
+
+  /**
   * Switches to another settings page
   *
   * @param {jQuery} linkSelector jQuery selector of the link that has been clicked
@@ -318,6 +369,38 @@ class SettingsGUI {
   static changeLeagueSetting(league) {
     config.set("league", league);
     windowManager.bridge.emit('league-change', {'league': league});
+  }
+
+  /**
+  * Changes the provider used for querying item prices
+  *
+  * @param {string} type Item type (rare / others)
+  * @param {string} provider Price provider
+  */
+  static changePriceProvider(type, provider) {
+    config.set("provider_"+type, provider);
+    windowManager.bridge.emit("provider-change", {'provider': provider});
+    windowManager.bridge.emit("provider-"+type+"-change", {'provider': provider});
+  }
+
+  /**
+  * Changes the poe data login username in config and update poe-data
+  *
+  * @param {string} username Username that is used for logging in
+  */
+  static changePoeDataLogin(username) {
+    config.set("poeDataLogin", username);
+    windowManager.bridge.emit('poe-data-login-change', {'username': username});
+  }
+
+  /**
+  * Changes the poe data login password in config and update poe-data
+  *
+  * @param {string} password Password that is used for logging in
+  */
+  static changePoeDataPass(password) {
+    config.set("poeDataPassword", password);
+    windowManager.bridge.emit('poe-data-pass-change', {'password': password});
   }
 }
 

--- a/src/modules/helpers.js
+++ b/src/modules/helpers.js
@@ -275,7 +275,13 @@ class Helpers {
           locked: false,
           poll: 1000,
           zoomFactor: 1
-        }
+        },
+        provider_rare: "poeprices",
+        provider_currency: "poeninja",
+        provider_others: "poeninja",
+        poeDataInterval: 0,
+        poeDataLogin: "",
+        poeDataPassword: ""
       }
     });
 
@@ -297,6 +303,26 @@ class Helpers {
     // 0.4.0
     if(!config.has("hideMenu")) {
       config.set("hideMenu", false);
+    }
+
+    // TODO: Put in Version number if merged
+    if(!config.has("provider_rare")) {
+      config.set("provider_rare", "poeprices");
+    }
+    if(!config.has("provider_currency")) {
+      config.set("provider_currency", "poeninja");
+    }
+    if(!config.has("provider_others")) {
+      config.set("provider_others", "poeninja");
+    }
+    if(!config.has("poeDataInterval")) {
+      config.set("poeDataInterval", 0);
+    }
+    if(!config.has("poeDataLogin")) {
+      config.set("poeDataLogin", "");
+    }
+    if(!config.has("poeDataEnabled")) {
+      config.set("poeDataEnabled", "");
     }
 
     return config;

--- a/src/modules/item-mod-parser.js
+++ b/src/modules/item-mod-parser.js
@@ -1,0 +1,64 @@
+'use strict';
+
+module.exports = class ItemModParser {
+  constructor(...mods) {
+    this.lines = [];
+    this.modsPossible = mods;
+    this.modsPossible.sort((a, b) => {
+      let lineDiff = b.getRegExpCount() - a.getRegExpCount();
+      let idAlphabetic = (a.modId < b.modId ? -1 : (a.modId > b.modId ? 1 : 0)); 
+      return (lineDiff != 0 ? lineDiff : idAlphabetic);
+    });
+    this.modsFound = [];
+  }
+  addModsManually(...mods) {
+    this.modsFound.push(...mods);
+  }
+  getMods() {
+    return this.modsFound;
+  }
+  getLines() {
+    return this.lines;
+  }
+  setLines(lines) {
+    this.lines = lines;
+  }
+  match(lines) {
+    this.lines = lines.slice(0);
+    this.modsFound = [];
+    for (let i = 0; i < this.modsPossible.length; i++) {
+      let modCurrent = this.modsPossible[i];
+      let modCurrentLines = [];
+      let modCurrentMatches = [];
+      let modCurrentRegExps = modCurrent.getRegExpList();
+      for (let r = 0; r < modCurrentRegExps.length; r++) {
+        for (let l = 0; l < this.lines.length; l++) {
+          let match = this.lines[l].match(modCurrentRegExps[r]);
+          if (match) {
+            modCurrentLines.push(l);
+            modCurrentMatches.push(match);
+            break;
+          }
+        }
+      }
+      if (modCurrentMatches.length == modCurrentRegExps.length) {
+        // Mod matched completely, add to matches
+        modCurrent = modCurrent.clone();
+        for (let r = 0; r < modCurrentMatches.length; r++) {
+          modCurrent.setValuesByMatch(modCurrentMatches[r], r);
+        }
+        if (modCurrent.validateValues()) {
+          // Add mod to result
+          this.modsFound.push(modCurrent);
+          // Remove matched lines
+          for (let l = this.lines.length - 1; l >= 0; l--) {
+            if (modCurrentLines.indexOf(l) >= 0) {
+              this.lines.splice(l, 1);
+            }
+          }
+        }
+      }
+    }
+    return (this.lines.length == 0);
+  }
+};

--- a/src/modules/item-mod.js
+++ b/src/modules/item-mod.js
@@ -1,0 +1,162 @@
+'use strict';
+
+module.exports = class ItemMod {
+  constructor(modData, modTrade, modType, values) {
+    this.modId = (typeof modData != "undefined" ? modData.id : null);
+    this.modBase = (typeof modData != "undefined" ? modData : null);
+    this.modTrade = (typeof modTrade != "undefined" ? modTrade : null);
+    this.modType = (typeof modType != "undefined" ? modType : null);
+    this.regExp = null;
+    this.values = (typeof values != "undefined" ? values : null);
+  }
+  clone() {
+    return new ItemMod(this.modBase, this.modTrade, this.values);
+  }
+  escapeRegExpString(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+  getRegExp(index) {
+    return this.getRegExpList()[index];
+  }
+  getRegExpList() {
+    if (this.regExp === null) {
+      let modText = null;
+      if (this.modBase !== null) {
+        modText = this.modBase['trade text'];
+      } else if (this.modTrade !== null) {
+        modText = this.modTrade.text;
+      }
+      if (modText !== null ) {
+        this.regExp = [];
+        let modRegExpLines = modText.split("\n");
+        for (let i = 0; i < modRegExpLines.length; i++) {
+          if (this.modType == "Crafted") {
+            modRegExpLines[i] += " (crafted)";
+          }
+          let modRegExpSplit = this.escapeRegExpString(modRegExpLines[i]).split("#");
+          this.regExp.push( new RegExp("^"+modRegExpSplit.join("([\\+\\-]?[0-9\\.]+)( to ([\\+\\-]?[0-9\\.]+))?")+"$", "i") );
+        }
+      }
+    }
+    return this.regExp;
+  }
+  getRegExpCount() {
+    return this.getRegExpList().length;
+  }
+  getGroup() {
+    if (this.modBase !== null) {
+      return this.modBase["mod group"];
+    }
+    return null;
+  }
+  getRequiredLevel() {
+    if (this.modBase !== null) {
+      return parseInt(this.modBase["required level"]);
+    }
+    return 0;
+  }
+  getTradeIds() {
+    let tradeIds = [];
+    for (let i = 0; i < this.modTrade.length; i++) {
+      tradeIds.push(this.modTrade[i] !== null ? this.modTrade[i].id : null);
+    }
+    return tradeIds;
+  }
+  getValueMin(index) {
+    let result = null;
+    let limits = this.modBase['trade limits'];
+    if (typeof index == "undefined") {
+      for (let i = 0; i < limits.length; i++) {
+        let value = this.getValueMin(i);
+        if ((result === null) || (value < result)) {
+          result = value;
+        }
+      }
+    } else {      
+      for (let v = 0; v < limits[index].length; v++) {
+        let value = parseFloat(limits[index][v]);
+        if ((result === null) || (value < result)) {
+          result = value;
+        }
+      }
+    }
+    return result;
+  }
+  getValueMax(index) {
+    let result = null;
+    let limits = this.modBase['trade limits'];
+    if (typeof index == "undefined") {
+      for (let i = 0; i < limits.length; i++) {
+        let value = this.getValueMax(i);
+        if ((result === null) || (value > result)) {
+          result = value;
+        }
+      }
+    } else {      
+      for (let i = 0; i < limits[index].length; i++) {
+        for (let v = 0; v < limits[index][i].length; v++) {
+          let value = parseFloat(limits[index][i][v]);
+          if ((result === null) || (value > result)) {
+            result = value;
+          }
+        }
+      }
+    }
+    return result;
+  }
+  getValueAvg(index) {
+    let result = 0;
+    let resultCount = 0;
+    if (typeof index == "undefined") {
+      for (let i in this.values) {
+        let value = this.getValueAvg(i);
+        result += value;
+        resultCount++;
+      }
+    } else {      
+      for (let v = 0; v < this.values[index].length; v++) {
+        let value = parseFloat(this.values[index][v]);
+        result += value;
+        resultCount++;
+      }
+    }
+    return result;
+  }
+  hasTag(tag) {
+    if (this.modBase === null) {
+      return false;
+    }
+    return (this.modBase.tags.indexOf(tag) >= 0)
+  }
+  setValuesByMatch(matchResult, index) {
+    if (this.values === null) {
+      this.values = {};
+    }
+    if (typeof this.values[index] == "undefined") {
+      this.values[index] = [];
+    }
+    for (let i = 1; i < matchResult.length; i++) {
+      if (typeof matchResult[i] == "undefined") {
+        continue;
+      }
+      if (!matchResult[i].match(/^[\+\-]?[0-9\\.]+$/)) {
+        continue;
+      }
+      this.values[index].push( parseFloat(matchResult[i]) );
+    }
+  }
+  validateValues() {
+    let limits = this.modBase['trade limits'];
+    for (let l = 0; l < limits.length; l++) {
+      for (let i = 0; i < limits[l].length; i++) {
+        if (typeof limits[l] == "undefined") {
+          return false;
+        }
+        if ((parseFloat(limits[l][i][0]) > this.values[l][i]) || (parseFloat(limits[l][i][1]) < this.values[l][i])) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+};

--- a/src/modules/item-sockets.js
+++ b/src/modules/item-sockets.js
@@ -1,0 +1,53 @@
+'use strict';
+
+module.exports = class ItemSockets {
+  constructor() {
+    this.count = 0;
+    this.links = [];
+  }
+  addLink(sockets) {
+    this.count += sockets.length;
+    this.links.push(sockets);
+  }
+  getMinLinkLength() {
+    let result = 0;
+    for (let l = 0; l < this.links.length; l++) {
+      result = Math.min(result, this.links[l].length);
+    }
+    return result;
+  }
+  getMaxLinkLength() {
+    let result = 0;
+    for (let l = 0; l < this.links.length; l++) {
+      result = Math.max(result, this.links[l].length);
+    }
+    return result;
+  }
+  getSocketCount(color) {
+    let result = 0;
+    for (let l = 0; l < this.links.length; l++) {
+      if (typeof color == "undefined") {
+        result += this.links[l].length;
+      } else {
+        for (let s = 0; s < this.links[l].length; s++) {
+          if (this.links[l][s] == color) {
+            result++;
+          }
+        }
+      }
+    }
+    return result;
+  }
+  getRedCount() {
+    return this.getSocketCount("R");
+  }
+  getGreenCount() {
+    return this.getSocketCount("G");
+  }
+  getBlueCount() {
+    return this.getSocketCount("B");
+  }
+  getWhiteCount() {
+    return this.getSocketCount("W");
+  }
+};

--- a/src/modules/item.js
+++ b/src/modules/item.js
@@ -1,0 +1,629 @@
+const parserBlockTypes = require("../resource/parserBlockTypes");
+
+const ItemSockets = require('./item-sockets.js');
+const ItemMod = require('./item-mod.js');
+const ItemModParser = require('./item-mod-parser.js');
+
+class Item {
+  /**
+  * Creates a new Item object
+  *
+  * @constructor
+  * @param {string} parser Parser object containing the item text
+  */
+  constructor(parser) {
+    this.parser = parser;
+    this.itemName = null;
+    this.itemRarity = null;
+    this.itemLevel = null;
+    this.itemBase = null;
+    this.requirements = {};
+    this.properties = {};
+    this.sockets = new ItemSockets();
+    this.modsImplicit = [];
+    this.modsImplicitParser = null;
+    this.modsImplicitPossible = null;
+    this.modsExplicit = [];
+    this.modsExplicitParser = null;
+    this.modsExplicitPossible = null;
+    this.modsCraftedPossible = null;
+    this.corrupted = false;
+    this.description = "";
+    this.helpText = "";
+    this.flavourText = "";
+    this.note = "";
+    this.analyse();
+  }
+  analyse() {
+    // Split lines by blocks and analyse those
+    let itemLines = this.parser.getClipboardLines();
+    let textBlock = [];
+    let textBlockIndex = 0;
+    let textBlockType = "unknown";
+    let textBlocksUnknown = [];
+    let textBlockDone = false;
+    for (let i = 0; i < itemLines.length; i++) {
+      let lineCurrent = itemLines[i];
+      // End of block?
+      if (lineCurrent == "--------") {
+        textBlockDone = true;
+      } else {
+        textBlock.push(lineCurrent);
+      }
+      if (textBlockDone || (i == itemLines.length-1)) {
+        textBlockType = this.detectBlockType(textBlock);
+        if (textBlockType != "unknown") {
+          this.analyseBlock(textBlock, textBlockType);
+        } else {
+          textBlocksUnknown.push(textBlock);
+        }
+        // Reset current block
+        textBlock = [];
+        textBlockIndex++;
+        textBlockType = "unknown";
+        textBlockDone = false;
+      }
+    }
+    // Try to detect the mod blocks within the remaining unknown blocks
+    for (let i = 0; i < textBlocksUnknown.length; i++) {
+      textBlock = textBlocksUnknown[i];
+      textBlockType = this.detectBlockTypeMods(textBlock);
+      this.analyseBlock(textBlock, textBlockType);
+    }
+    // Debug output
+    /*
+    console.log( "itemName: "+util.inspect(this.itemName, {depth: null}) );
+    console.log( "itemRarity: "+util.inspect(this.itemRarity, {depth: null}) );
+    console.log( "itemLevel: "+util.inspect(this.itemLevel, {depth: null}) );
+    console.log( "itemBase: "+util.inspect(this.itemBase, {depth: null}) );
+    console.log( "requirements: "+util.inspect(this.requirements, {depth: null}) );
+    console.log( "properties: "+util.inspect(this.properties, {depth: null}) );
+    console.log( "sockets: "+util.inspect(this.sockets, {depth: null}) );
+    console.log( "modsImplicit: "+util.inspect(this.modsImplicit, {depth: null}) );
+    console.log( "modsImplicitPossible: "+util.inspect(this.modsImplicitPossible.length, {depth: 1}) );
+    console.log( "modsExplicit: "+util.inspect(this.modsExplicit, {depth: null}) );
+    console.log( "modsExplicitPossible: "+util.inspect(this.modsExplicitPossible.length, {depth: 1}) );
+    console.log( "modsCraftedPossible: "+util.inspect(this.modsCraftedPossible.length, {depth: 1}) );
+    console.log( "corrupted: "+util.inspect(this.corrupted, {depth: null}) );
+    console.log( "helpText: "+util.inspect(this.helpText, {depth: null}) );
+    console.log( "flavourText: "+util.inspect(this.flavourText, {depth: null}) );
+    console.log( "note: "+util.inspect(this.note, {depth: null}) );
+    */
+  }
+  analyseBlock(lines, type) {
+    switch (type) {
+      case "name":
+        this.analyseName(lines);
+        break;
+      case "requirements":
+        this.analyseRequirements(lines);
+        break;
+      case "properties":
+        this.analyseProperties(lines);
+        break;
+      case "sockets":
+        this.analyseSockets(lines);
+        break;
+      case "itemLevel":
+        this.analyseItemLevel(lines);
+        break;
+      case "description":
+        this.analyseDescription(lines);
+        break;
+      case "helpText":
+        this.analyseHelpText(lines);
+        break;
+      case "flavourText":
+        this.analyseFlavourText(lines);
+        break;
+      case "corrupted":
+        this.analyseCorrupted(lines);
+        break;
+      case "note":
+        this.analyseNote(lines);
+        break;
+      case "modsImplicit":
+        this.analyseModsImplicit(lines);
+        break;
+      case "modsExplicit":
+        this.analyseModsExplicit(lines);
+        break;
+      default:
+        //throw new Error("[Item] Unknown block of type '"+type+"':\n"+lines.join("\n"));
+        break;
+    }
+  }
+  analyseName(lines) {
+    // Parse rarity and item name
+    let rarityMatch = lines[0].match(/^Rarity: (.+)$/i);
+    if (rarityMatch) {
+      this.itemRarity = rarityMatch[1];
+    }
+    this.itemName = (this.itemRarity == "Unique" ? lines[ lines.length-2 ] : lines[ lines.length-1 ]);
+    this.itemBase = poeData.getItemBase(this.itemName, this.getArmourTag());
+  }
+  analyseRequirements(lines) {
+    lines.shift();
+    for (let l = 0; l < lines.length; l++) {
+      let match = lines[l].match(/^(.+?)(: (.+))?$/i);
+      if (match) {
+        let name = match[1];
+        let value = (typeof match[3] == "undefined" ? true : match[3]);
+        this.requirements[name] = value;
+      } else {
+        throw new Error("[Item] Unexpected requirement property:\n"+lines[l]);
+      }
+    }
+    // Reevaluate the correct base item with the additional information available
+    this.itemBase = poeData.getItemBase(this.itemName, this.getArmourTag());
+  }
+  analyseProperties(lines) {
+    let propertyPrefix = "";
+    if (this.hasTag("gem")) {
+      if (typeof this.properties["Gem Tags"] == "undefined") {
+        this.properties["Gem Tags"] = {
+          value: lines.shift().split(", "),
+          augmented: false
+        }
+      } else if (this.properties["Gem Tags"].value.indexOf("Vaal") >= 0) {
+        propertyPrefix = "Vaal ";
+      }
+    }
+    for (let l = 0; l < lines.length; l++) {
+      let match = lines[l].match(/^(.+?)(: (.+))?$/i);
+      if (match) {
+        let name = propertyPrefix+match[1];
+        let value = (typeof match[3] == "undefined" ? true : match[3]);
+        let augmented = false;
+        if (value !== true) {
+          // Check if augmented
+          let matchAugmented = value.match(/^(.+?) \(augmented\)/);
+          if (matchAugmented) {
+            value = matchAugmented[1];
+            augmented = true;
+          }
+          // Split values (min-max)
+          value = value.split("-");
+        }
+        this.properties[name] = {
+          value: value,
+          augmented: augmented
+        };
+      } else {
+        throw new Error("[Item] Unexpected item property:\n"+lines[l]);
+      }
+    }
+  }
+  analyseSockets(lines) {
+    let socketRegExp = new RegExp(parserBlockTypes["sockets"].regex);
+    let socketMatch = lines[0].match(socketRegExp);
+    if (socketMatch) {
+      let socketLinks = socketMatch[1].trim().split(" ");
+      for (let l = 0; l < socketLinks.length; l++) {
+        this.sockets.addLink( socketLinks[l].split("-") );
+      }
+    }
+  }
+  analyseItemLevel(lines) {
+    let itemLevelRegExp = new RegExp(parserBlockTypes["itemLevel"].regex);
+    let itemLevelMatch = lines[0].match(itemLevelRegExp);
+    if (itemLevelMatch) {
+      this.itemLevel = parseInt(itemLevelMatch[1]);
+    }
+  }
+  analyseFlavourText(lines) {
+    if (this.flavourText != "") {
+      this.flavourText += "\n";
+    }
+    this.flavourText += lines.join("\n");
+  }
+  analyseDescription(lines) {
+    if (this.description != "") {
+      this.description += "\n";
+    }
+    this.description += lines.join("\n");
+  }
+  analyseHelpText(lines) {
+    if (this.helpText != "") {
+      this.helpText += "\n";
+    }
+    this.helpText += lines.join("\n");
+  }
+  analyseCorrupted(lines) {
+    this.corrupted = true;
+  }
+  analyseNote(lines) {
+    let noteRegExp = new RegExp(parserBlockTypes["itemLevel"].regex);
+    let noteMatch = lines[0].match(noteRegExp);
+    if (noteMatch) {
+      this.note = noteMatch[1];
+    }
+  }
+  analyseModsImplicit(lines) {
+    this.modsImplicit.push( ...this.getImplicitModsParser().getMods() );
+  }
+  analyseModsExplicit(lines) {
+    this.modsExplicit.push( ...this.getExplicitModsParser().getMods() );
+  }
+  detectBlockType(lines) {
+    let type = "unknown";
+    // Check for item specific blocks
+    if (this.itemBase !== null) {
+      if (this.itemBase['flavour text'].replace(/\s*/g, " ") == lines.join("\n").replace(/\s*/g, " ")) {
+        return "flavourText";
+      }
+      if (this.itemBase['description'].replace(/\s*/g, " ") == lines.join("\n").replace(/\s*/g, " ")) {
+        return "description";
+      }
+      if (this.itemBase['help text'].replace(/\s*/g, " ") == lines.join("\n").replace(/\s*/g, " ")) {
+        return "helpText";
+      }
+      if (this.hasTag("gem") && (lines[0] == "Vaal "+this.itemName)) {
+        return "name";
+      }
+    }
+    // Check simple type detection as defined in "resource/parserBlockTypes.json"
+    for (let typeIndicator in parserBlockTypes) {
+      for (let l = 0; l < lines.length; l++) {
+        var regex = new RegExp(parserBlockTypes[typeIndicator].regex);
+        var match = lines[l].match(regex);
+        if(match) {
+          return parserBlockTypes[typeIndicator].type;
+        }
+      }
+    }
+    return type;
+  }
+  detectBlockTypeMods(lines) {
+    if (this.getImplicitModsParser().match(lines)) {
+      return "modsImplicit";
+    }
+    if (this.getExplicitModsParser().match(lines)) {
+      return "modsExplicit";
+    }
+    if (this.getExplicitModsParser().getMods().length > 0) {
+      let remainingLines = this.getExplicitModsParser().getLines();
+      console.log("Warning: Some mods were not detected:\n"+remainingLines.join("\n"));
+      // Try to match the remaining mods ignoring spawn weights
+      let anyMods = poeData.getModsByParams({
+        domains: [ this.getModDomain() ],
+        generations: [ poeData.MOD_GEN_TYPE_PREFIX, poeData.MOD_GEN_TYPE_SUFFIX ]
+      });
+      let anyModObjects = [];
+      for (let i = 0; i < anyMods.length; i++) {
+        let modDetail = anyMods[i];
+        let modObject = this.getModObject(modDetail, "Explicit");
+        if (modObject.getRequiredLevel() <= this.itemLevel) {
+          anyModObjects.push(modObject);
+        }
+      }
+      let anyModParser = new ItemModParser(...anyModObjects);
+      if (anyModParser.match(remainingLines)) {
+        this.getExplicitModsParser().addModsManually(...anyModParser.getMods());
+        this.getExplicitModsParser().setLines( anyModParser.getLines() );
+        console.log("Info: Detected remaining mods ignoring spawn weights.");
+      }
+      return "modsExplicit";
+    }
+    return "unknown";
+  }
+  getModObject(modDetail, type) {
+    let modTradeList = [];
+    for (let l = 0; l < modDetail['trade ids'].length; l++) {
+      let modTradeId = null;
+      for (let t = 0; t < modDetail['trade ids'][l].length; t++) {
+        if (modDetail['trade ids'][l][t].indexOf(type.toLowerCase()+".") == 0) {
+          modTradeId = modDetail['trade ids'][l][t];
+          break;
+        }
+      }
+      let modTrade = (modTradeId !== null ? poeData.getModTradeById(modTradeId, type) : null);
+      modTradeList.push(modTrade);
+    }
+    return new ItemMod(modDetail, modTradeList, type);
+  }
+  getImplicitMods() {
+    return this.modsImplicit;
+  }
+  getImplicitModsParser() {
+    if (this.modsImplicitParser === null) {
+      this.modsImplicitParser = new ItemModParser( ...this.getImplicitModsPossible() );
+    }
+    return this.modsImplicitParser;
+  }
+  getImplicitModsPossible() {
+    if (this.modsImplicitPossible === null) {
+      this.modsImplicitPossible = [];
+      if (this.itemBase !== null) {
+        // Get implicits from base item
+        for (let i = 0; i < this.itemBase['mods'].length; i++) {
+          let itemMod = this.itemBase['mods'][i];
+          if (itemMod['is implicit'] != 1) {
+            continue;
+          }
+          let modDetail = poeData.getModByIdent(itemMod['id']);
+          let modObject = this.getModObject(modDetail, "Implicit");
+          if (modObject.getRequiredLevel() <= this.itemLevel) {
+            this.modsImplicitPossible.push(modObject);
+          }
+        }
+        // Get enchantments
+        let enchantmentMods = poeData.getModsByParams({
+          domains: [ this.getModDomain() ],
+          generations: [ poeData.MOD_GEN_TYPE_ENCHANTMENT ],
+          spawnTags: this.itemBase.tags
+        });
+        for (let i = 0; i < enchantmentMods.length; i++) {
+          let modDetail = enchantmentMods[i];
+          let modObject = this.getModObject(modDetail, "Enchant");
+          if (modObject.getRequiredLevel() <= this.itemLevel) {
+            this.modsImplicitPossible.push(modObject);
+          }
+        }
+        // Get corrupted mods
+        if (this.corrupted) {
+          let corruptedMods = poeData.getModsByParams({
+            domains: [ this.getModDomain() ],
+            generations: [ poeData.MOD_GEN_TYPE_CORRUPTED ],
+            spawnTags: this.itemBase.tags
+          });
+          for (let i = 0; i < corruptedMods.length; i++) {
+            let modDetail = corruptedMods[i];
+            let modObject = this.getModObject(modDetail, "Implicit");
+            if (modObject.getRequiredLevel() <= this.itemLevel) {
+              this.modsImplicitPossible.push(modObject);
+            }
+          }
+        }
+      }
+    }
+    return this.modsImplicitPossible;
+  }
+  getExplicitMods() {
+    return this.modsExplicit;
+  }
+  getExplicitModsParser() {
+    if (this.modsExplicitParser === null) {
+      this.modsExplicitParser = new ItemModParser( ...this.getExplicitModsPossible(), ...this.getCraftedModsPossible() );
+    }
+    return this.modsExplicitParser;
+  }
+  getExplicitModsPossible() {
+    if (this.modsExplicitPossible === null) {
+      this.modsExplicitPossible = [];
+      // Get explicits from base item
+      for (let i = 0; i < this.itemBase['mods'].length; i++) {
+        let itemMod = this.itemBase['mods'][i];
+        if (itemMod['is implicit']) {
+          continue;
+        }
+        let modDetail = poeData.getModByIdent(itemMod['id']);
+        let modObject = this.getModObject(modDetail, "Explicit");
+        if (modObject.getRequiredLevel() <= this.itemLevel) {
+          this.modsExplicitPossible.push(modObject);
+        }
+      }
+      // Get regular explicits for the item
+      let baselineMods = poeData.getModsByParams({
+        domains: [ this.getModDomain() ],
+        generations: [ poeData.MOD_GEN_TYPE_PREFIX, poeData.MOD_GEN_TYPE_SUFFIX ],
+        spawnTags: this.itemBase.tags
+      });
+      for (let i = 0; i < baselineMods.length; i++) {
+        let modDetail = baselineMods[i];
+        let modObject = this.getModObject(modDetail, "Explicit");
+        if (modObject.getRequiredLevel() <= this.itemLevel) {
+          this.modsExplicitPossible.push(modObject);
+        }
+      }
+      // Get corrupted mods
+      if (this.corrupted) {
+        let corruptedMods = poeData.getModsByParams({
+          domains: [ this.getModDomain() ],
+          generations: [ poeData.MOD_GEN_TYPE_CORRUPTED ],
+          spawnTags: this.itemBase.tags
+        });
+        for (let i = 0; i < corruptedMods.length; i++) {
+          let modDetail = corruptedMods[i];
+          let modObject = this.getModObject(modDetail, "Explicit");
+          if (modObject.getRequiredLevel() <= this.itemLevel) {
+            this.modsExplicitPossible.push(modObject);
+          }
+        }
+      }
+    }
+    return this.modsExplicitPossible;
+  }
+  getCraftedModsPossible() {
+    if (this.modsCraftedPossible === null) {
+      this.modsCraftedPossible = [];
+      // Get crafted explicits for the item
+      let craftedMods = poeData.getModsByParams({
+        domains: [ poeData.MOD_GEN_TYPE_PREFIX, poeData.MOD_GEN_TYPE_SUFFIX, poeData.MOD_DOMAIN_CRAFTED ],
+        spawnTags: this.itemBase.tags
+      });
+      for (let i = 0; i < craftedMods.length; i++) {
+        let modDetail = craftedMods[i];
+        let modObject = this.getModObject(modDetail, "Crafted");
+        if (modObject.getRequiredLevel() <= this.itemLevel) {
+          this.modsCraftedPossible.push(modObject);
+        }
+      }
+    }
+    return this.modsCraftedPossible;
+  }
+  getModDomain() {
+    if (this.itemBase !== null) {
+      if (this.itemBase['class id'] == "Leaguestone") {
+        return poeData.MOD_DOMAIN_LEAGUESTONE;
+      }
+      if (this.hasTag("flask")) {
+        return poeData.MOD_DOMAIN_FLASK;
+      }
+      if (this.hasTag("abyss_jewel")) {
+        return poeData.MOD_DOMAIN_ABYSS_JEWEL;
+      }
+      if (this.hasTag("jewel")) {
+        return poeData.MOD_DOMAIN_JEWEL;
+      }
+    }
+    return poeData.MOD_DOMAIN_ITEM;
+  }
+  getName() {
+    return this.itemName;
+  }
+  getRarity() {
+    return this.itemRarity;
+  }
+  getArmour() {
+    let prop = this.getProperty("Armour");
+    return parseInt(prop.value[0]);
+  }
+  getEnergyShield() {
+    let prop = this.getProperty("Energy Shield");
+    return parseInt(prop.value[0]);
+  }
+  getEvasion() {
+    let prop = this.getProperty("Evasion Rating");
+    return parseInt(prop.value[0]);
+  }
+  getBlock() {
+    let prop = this.getProperty("Chance to Block");
+    return Math.round(parseFloat(prop.value[0]) * 100) / 100;
+  }
+  getQuality() {
+    let prop = this.getProperty("Quality");
+    return parseFloat(prop.value[0]);
+  }
+  getProperty(name) {
+    if (typeof this.properties[name] != "undefined") {
+      return this.properties[name];
+    } else {
+      return { value: [ 0 ], augmented: false };
+    }
+  }
+  getRequirement(name) {
+    if (typeof this.requirements[name] != "undefined") {
+      return parseInt(this.requirements[name]);
+    } else {
+      return 0;
+    }
+  }
+  getSocketCount() {
+    return this.sockets.getSocketCount();
+  }
+  getSocketCountMax() {
+    if (this.hasTag("weapon") || this.hasTag("armour")) {
+      if (!this.isFourSocket() && !this.isThreeSocket()) {
+        if (this.itemLevel >= 50) {
+          return 6;
+        }
+        if (this.itemLevel >= 35) {
+          return 5;
+        }
+      }
+      if (!this.isThreeSocket()) {
+        if (this.itemLevel >= 25) {
+          return 4;
+        }
+      }
+      if (this.itemLevel >= 1) {
+        return 3;
+      }
+      return 2;
+    }
+    return (this.isSingleSocket() ? 1 : 0);
+  }
+  getMinLinkLength() {
+    return this.sockets.getMinLinkLength();
+  }
+  getMaxLinkLength() {
+    return this.sockets.getMaxLinkLength();
+  }
+  getArmourTag() {
+    if ((this.getArmour() == 0) && (this.getEvasion() == 0) && (this.getEnergyShield() == 0)) {
+      // Not an armour
+      return null;
+    }
+    let reqStr = this.getRequirement("Str");
+    let reqDex = this.getRequirement("Dex");
+    let reqInt = this.getRequirement("Int");
+    if ((reqStr > 0) && (reqDex > 0)) {
+      return "str_dex_armour";
+    }
+    if ((reqStr > 0) && (reqInt > 0)) {
+      return "str_int_armour";
+    }
+    if ((reqDex > 0) && (reqInt > 0)) {
+      return "dex_int_armour";
+    }
+    if (reqStr > 0) {
+      return "str_armour";
+    }
+    if (reqDex > 0) {
+      return "dex_armour";
+    }
+    if (reqInt > 0) {
+      return "int_armour";
+    }
+    return "armour";
+  }
+  getTags() {
+    if (this.itemBase === null) {
+      return [];
+    }
+    return this.itemBase.tags;
+  }
+  getDPS() {
+    return this.getPhysicalDPS() + this.getElementalDPS(); 
+  }
+  getPhysicalDPS() {
+    let aps = this.getProperty("Attacks per Second");
+    let damage = this.getProperty("Physical Damage");
+    let damageAvg = 0;
+    for (let i = 0; i < damage.value.length; i++) {
+      damageAvg += parseFloat(damage.value[i]);
+    }
+    damageAvg /= damage.value.length;
+    return damageAvg * aps.value[0];
+  }
+  getElementalDPS() {
+    let aps = this.getProperty("Attacks per Second");
+    let damage = this.getProperty("Elemental Damage");
+    let damageAvg = 0;
+    for (let i = 0; i < damage.value.length; i++) {
+      damageAvg += parseFloat(damage.value[i]);
+    }
+    damageAvg /= damage.value.length;
+    return damageAvg * aps.value[0];
+  }
+  isFourSocket() {
+    if (this.hasTag("gloves") || this.hasTag("boots") || this.hasTag("helmet")) {
+      return true;
+    }
+    return false;
+  }
+  isThreeSocket() {
+    if (this.hasTag("one_hand_weapon") || this.hasTag("shield") || this.hasTag("quiver")) {
+      return true;
+    }
+    return false;
+  }
+  isSingleSocket() {
+    if (this.hasTag("ring")) {
+      return true;
+    }
+    return false;
+  }
+  isCorrupted() {
+    return this.corrupted;
+  }
+  hasTag(tag) {
+    if (this.itemBase === null) {
+      return false;
+    }
+    return (this.itemBase.tags.indexOf(tag) >= 0)
+  }
+}
+
+module.exports = Item;

--- a/src/modules/parser.js
+++ b/src/modules/parser.js
@@ -2,6 +2,7 @@ const itemVariants = require("../resource/itemVariants");
 const gemVariants = require("../resource/gemVariants");
 const parserTypes = require("../resource/parserTypes");
 const mapAffixes = require("../resource/mapAffixes");
+const Item = require("./item.js");
 
 class Parser {
   /**
@@ -12,8 +13,17 @@ class Parser {
   */
   constructor(clipboard) {
     this.clipboard = clipboard;
-
     this.fixCannotUseText();
+    // Try to parse the detailed item data
+    this.item = null;
+    if (this.isPathOfExileData() && !poeData.isUpdating()) {
+      try {
+        this.item = new Item(this);
+      } catch(error) {
+        console.error(error.message);
+        console.log(error.stack);
+      }
+    }
   }
 
   /**

--- a/src/modules/poedata.js
+++ b/src/modules/poedata.js
@@ -1,0 +1,884 @@
+'use strict';
+
+// Nodejs dependencies
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const request = require('request');
+const zlib = require('zlib');
+const htmlEntities = require('html-entities').XmlEntities;
+
+class PoeData {
+  constructor() {
+    // Constants
+    this.constantsInit();
+    // Wiki session
+    this.wikiLoginToken = null;
+    this.wikiLimit = 5000;
+    // https://pathofexile.gamepedia.com/Special:CargoTables
+    this.wikiData = {
+      items: {},
+      mods: {}
+    };
+    this.tradeData = {
+      // https://www.pathofexile.com/api/trade/data/leagues
+      leagues: null,
+      // https://www.pathofexile.com/api/trade/data/static
+      cards: null,
+      currency: null,
+      mapsBase: null,
+      mapsElder: null,
+      essences: null,
+      fossils: null,
+      fragments: null,
+      incubators: null,
+      leaguestones: null,
+      resonators: null,
+      scarabs: null,
+      vials: null,
+      // https://www.pathofexile.com/api/trade/data/stats
+      stats: null
+    };
+    // Flag for checking if an update is pending
+    this.updateActive = false;
+    // Read values from cache
+    this.readCache();
+  }
+  constantsInit() {
+    // Mod domains
+    this.MOD_DOMAIN_ITEM = 1;
+    this.MOD_DOMAIN_FLASK = 2;
+    this.MOD_DOMAIN_MONSTER = 3;
+    this.MOD_DOMAIN_CHEST = 4;
+    this.MOD_DOMAIN_AREA = 5;
+    this.MOD_DOMAIN_UNKNOWN6 = 6;
+    this.MOD_DOMAIN_UNKNOWN7 = 7;
+    this.MOD_DOMAIN_UNKNOWN8 = 8;
+    this.MOD_DOMAIN_CRAFTED = 9;
+    this.MOD_DOMAIN_JEWEL = 10;
+    this.MOD_DOMAIN_ATLAS = 11;
+    this.MOD_DOMAIN_LEAGUESTONE = 12;
+    this.MOD_DOMAIN_ABYSS_JEWEL = 13;
+    this.MOD_DOMAIN_MAP_DEVICE = 14;
+    this.MOD_DOMAIN_UNKNOWN15 = 15;
+    this.MOD_DOMAIN_DELVE = 16;
+    this.MOD_DOMAIN_DELVE_AREA = 17;
+    this.MOD_DOMAIN_SYNTHESIS18 = 18;
+    this.MOD_DOMAIN_SYNTHESIS19 = 19;
+    this.MOD_DOMAIN_SYNTHESIS20 = 20;
+    // Mod generation types
+    this.MOD_GEN_TYPE_PREFIX = 1;
+    this.MOD_GEN_TYPE_SUFFIX = 2;
+    this.MOD_GEN_TYPE_UNIQUE = 3;
+    this.MOD_GEN_TYPE_NEMESIS = 4;
+    this.MOD_GEN_TYPE_CORRUPTED = 5;
+    this.MOD_GEN_TYPE_BLOODLINES = 6;
+    this.MOD_GEN_TYPE_TORMENT = 7;
+    this.MOD_GEN_TYPE_TEMPEST = 8;
+    this.MOD_GEN_TYPE_TALISMAN = 9;
+    this.MOD_GEN_TYPE_ENCHANTMENT = 10;
+    this.MOD_GEN_TYPE_ESSENCE = 11;
+    this.MOD_GEN_TYPE_UNKNOWN12 = 12;
+    this.MOD_GEN_TYPE_BESTIARY = 13;
+    this.MOD_GEN_TYPE_DELVE = 14;
+    this.MOD_GEN_TYPE_SYNTHESIS15 = 15;
+    this.MOD_GEN_TYPE_SYNTHESIS16 = 16;
+    this.MOD_GEN_TYPE_SYNTHESIS17 = 17;
+  }
+  decodeHtml(text) {
+    return htmlEntities.decode(text).replace(/<br\s*\/?>/g, "\n");
+  }
+  escapeRegExpString(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+  getMaps(mapType) {
+    if (typeof mapType == "undefined") {
+      mapType = "Base";
+    }
+    switch (mapType) {
+      default:
+      case "Base":
+        return this.tradeData.mapsBase;
+      case "Elder":
+        return this.tradeData.mapsElder;
+    }
+  }
+  getItemBase(itemBaseName, armourTag) {
+    let itemBaseIds = this.wikiData.items.byName[itemBaseName];
+    if (typeof itemBaseIds == "undefined") {
+      // Item most likely has a prefix and/or suffix attached to the name, find the best match
+      let itemSearchBestName = "";
+      let itemSearchBestId = null;
+      for (let itemSearchName in this.wikiData.items.byName) {
+        if ((itemBaseName.indexOf(itemSearchName) >= 0) && (itemSearchName.length > itemSearchBestName.length)) {
+          itemSearchBestName = itemSearchName;
+          itemSearchBestId = this.wikiData.items.byName[itemSearchName];
+        }
+      }
+      itemBaseIds = itemSearchBestId;
+    }
+    if (itemBaseIds.length == 1) {
+      return this.wikiData.items.byId[itemBaseIds[0]];
+    } else if (itemBaseIds.length > 1) {
+      let itemBaseResult = null;
+      // Multiple items found! Pick the matching one.
+      for (let i = 0; i < itemBaseIds.length; i++) {
+        let itemBase = this.wikiData.items.byId[itemBaseIds[i]];
+        if (armourTag !== null) {
+          if (itemBase.tags.indexOf(armourTag) == -1) {
+            // Item does not match the expected type of armour, ignore this one.
+            continue;
+          }
+        }
+        itemBaseResult = itemBase;
+        break;
+      }
+      return itemBaseResult;
+    }
+    return null;
+  }
+  getModById(modId) {
+    let mod = this.wikiData.mods.byId[ modId ];
+    return (typeof mod == "undefined" ? null : mod);
+  }
+  getModByIdent(modIdent) {
+    let modId = this.wikiData.mods.byModIdent[ modIdent ];
+    return this.getModById(modId);
+  }
+  getModsById(modIds) {
+    // Resolve ids into mods
+    let mods = [];
+    for (let m = 0; m < modIds.length; m++) {
+      mods.push( this.getModById(modIds[m]) );
+    }
+    return mods;
+  }
+  getModsByParams(params) {
+    let modIds = null;
+    if (typeof params.domains != "undefined") {
+      // Get mods by domains
+      // https://pathofexile.gamepedia.com/Modifiers#Mod_Domain
+      let modsByDomains = [];
+      for (let i = 0; i < params.domains.length; i++) {
+        modsByDomains.push(...this.wikiData.mods.byDomain[ params.domains[i] ]);
+      }
+      // Remove duplicates
+      modsByDomains = [...new Set(modsByDomains)];
+      // Set or filter result list
+      modIds = (modIds === null ? modsByDomains : modsByDomains.filter(value => modIds.includes(value)));
+    }
+    if (typeof params.generations != "undefined") {
+      // Get mods by generation types
+      // https://pathofexile.gamepedia.com/Modifiers#Mod_Generation_Type
+      let modsByGenerations = [];
+      for (let i = 0; i < params.generations.length; i++) {
+        modsByGenerations.push(...this.wikiData.mods.byGeneration[ params.generations[i] ]);
+      }
+      // Remove duplicates
+      modsByGenerations = [...new Set(modsByGenerations)];
+      // Set or filter result list
+      modIds = (modIds === null ? modsByGenerations : modsByGenerations.filter(value => modIds.includes(value)));
+    }
+    if (typeof params.spawnTags != "undefined") {
+      // Get mods by spawn tags
+      // https://pathofexile.gamepedia.com/Modifiers#Tags
+      let modsBySpawnTags = [];
+      for (let i = 0; i < params.spawnTags.length; i++) {
+        if (typeof this.wikiData.mods.bySpawnTags[ params.spawnTags[i] ] == "undefined") {
+          // Skip unknown tags
+          continue;
+        }
+        for (let m = 0; m < this.wikiData.mods.bySpawnTags[ params.spawnTags[i] ].length; m++) {
+          modsBySpawnTags.push(this.wikiData.mods.bySpawnTags[ params.spawnTags[i] ][m].modId);
+        }
+      }
+      // Remove duplicates
+      modsBySpawnTags = [...new Set(modsBySpawnTags)];
+      // Set or filter result list
+      modIds = (modIds === null ? modsBySpawnTags : modsBySpawnTags.filter(value => modIds.includes(value)));
+    }
+    return this.getModsById(modIds);
+  }
+  getModTradeById(modTradeId, statType) {
+    let modTrade = this.tradeData.stats[statType][modTradeId];
+    return (typeof modTrade != "undefined" ? { id: modTradeId, text: modTrade } : null);
+  }
+  getCurrencyName(currencyIdent) {
+    let currencyName = this.tradeData.currency[currencyIdent];
+    return (typeof currencyName != "undefined" ? currencyName : null);
+  }
+  getCurrencyItemText(currencyIdent, amount) {
+    let currencyName = this.getCurrencyName(currencyIdent);
+    let currencyItem = this.getItemBase(currencyName);
+    let currencyText = [];
+    currencyText.push("Rarity: Currency");
+    currencyText.push(currencyName);
+    currencyText.push("--------");
+    currencyText.push("Stack Size: "+amount+"/10");
+    currencyText.push("--------");
+    currencyText.push(this.decodeHtml(currencyItem['description']));
+    currencyText.push("--------");
+    currencyText.push(this.decodeHtml(currencyItem['help text']));
+    return currencyText.join("\n");
+  }
+  handleLeagues(apiData) {
+    // Leagues
+    this.tradeData.leagues = {};
+    for (let leagueIndex = 0; leagueIndex < apiData.result.length; leagueIndex++) {
+      let leagueData = apiData.result[leagueIndex];
+      this.tradeData.leagues[leagueData.id] = leagueData.text;
+    }
+  }
+  handleStatic(apiData) {
+    // Cards
+    this.tradeData.cards = {};
+    for (let cardIndex = 0; cardIndex < apiData.result.cards.length; cardIndex++) {
+      let cardData = apiData.result.cards[cardIndex];
+      this.tradeData.cards[cardData.id] = cardData.text;
+    }
+    // Currency
+    this.tradeData.currency = {};
+    for (let currencyIndex = 0; currencyIndex < apiData.result.currency.length; currencyIndex++) {
+      let currencyData = apiData.result.currency[currencyIndex];
+      this.tradeData.currency[currencyData.id] = currencyData.text;
+    }
+    // Maps
+    this.tradeData.mapsBase = {};
+    this.tradeData.mapsElder = {};
+    for (let mapIndex = 0; mapIndex < apiData.result.maps.length; mapIndex++) {
+      let mapData = apiData.result.maps[mapIndex];
+      this.tradeData.mapsBase[mapData.id] = mapData.text;
+    }
+    for (let mapIndex = 0; mapIndex < apiData.result.elder_maps.length; mapIndex++) {
+      let mapData = apiData.result.elder_maps[mapIndex];
+      this.tradeData.mapsElder[mapData.id] = mapData.text;
+    }
+    // Essences
+    this.tradeData.essences = {};
+    for (let essenceIndex = 0; essenceIndex < apiData.result.essences.length; essenceIndex++) {
+      let essenceData = apiData.result.essences[essenceIndex];
+      this.tradeData.essences[essenceData.id] = essenceData.text;
+    }
+    // Fossils
+    this.tradeData.fossils = {};
+    for (let fossilIndex = 0; fossilIndex < apiData.result.fossils.length; fossilIndex++) {
+      let fossilData = apiData.result.fossils[fossilIndex];
+      this.tradeData.fossils[fossilData.id] = fossilData.text;
+    }
+    // Fragments
+    this.tradeData.fragments = {};
+    for (let fragmentIndex = 0; fragmentIndex < apiData.result.fragments.length; fragmentIndex++) {
+      let fragmentData = apiData.result.fragments[fragmentIndex];
+      this.tradeData.fragments[fragmentData.id] = fragmentData.text;
+    }
+    // Incubators
+    this.tradeData.incubators = {};
+    for (let incubatorIndex = 0; incubatorIndex < apiData.result.incubators.length; incubatorIndex++) {
+      let incubatorData = apiData.result.incubators[incubatorIndex];
+      this.tradeData.incubators[incubatorData.id] = incubatorData.text;
+    }
+    // Leaguestones
+    this.tradeData.leaguestones = {};
+    for (let leaguestoneIndex = 0; leaguestoneIndex < apiData.result.leaguestones.length; leaguestoneIndex++) {
+      let leaguestoneData = apiData.result.leaguestones[leaguestoneIndex];
+      this.tradeData.leaguestones[leaguestoneData.id] = leaguestoneData.text;
+    }
+    // Resonators
+    this.tradeData.resonators = {};
+    for (let resonatorIndex = 0; resonatorIndex < apiData.result.resonators.length; resonatorIndex++) {
+      let resonatorData = apiData.result.resonators[resonatorIndex];
+      this.tradeData.resonators[resonatorData.id] = resonatorData.text;
+    }
+    // Scarabs
+    this.tradeData.scarabs = {};
+    for (let scarabIndex = 0; scarabIndex < apiData.result.scarabs.length; scarabIndex++) {
+      let scarabData = apiData.result.scarabs[scarabIndex];
+      this.tradeData.scarabs[scarabData.id] = scarabData.text;
+    }
+    // Vials
+    this.tradeData.vials = {};
+    for (let vialIndex = 0; vialIndex < apiData.result.vials.length; vialIndex++) {
+      let vialData = apiData.result.vials[vialIndex];
+      this.tradeData.vials[vialData.id] = vialData.text;
+    }
+  }
+  handleStats(apiData) {
+    // Leagues
+    this.tradeData.stats = {};
+    for (let statTypeIndex = 0; statTypeIndex < apiData.result.length; statTypeIndex++) {
+      let statTypeData = apiData.result[statTypeIndex];
+      this.tradeData.stats[statTypeData.label] = {};
+      for (let entryIndex = 0; entryIndex < statTypeData.entries.length; entryIndex++) {
+        let entryData = statTypeData.entries[entryIndex];
+        this.tradeData.stats[statTypeData.label][entryData.id] = entryData.text;
+      }
+    }
+  }
+  async wikiGetLoginToken() {
+    let params = {
+      action: "query",
+      meta: "tokens",
+      type: "login",
+      format: "json"
+    }
+    let reply = await this.wikiSendRequest(params);
+    this.wikiLoginToken = reply.query.tokens.logintoken;
+    return true;
+  }
+  async wikiSendLogin(username, password) {
+    if (this.wikiLoginToken === null) {
+      // Ensure there is a login token available
+      await this.wikiGetLoginToken();
+    }
+    let params = {
+      action: "login",
+      lgname: username,
+      lgpassword: password,
+      lgtoken: this.wikiLoginToken,
+      format: "json"
+    }
+    let reply = await this.wikiSendRequest(params);
+    return (reply.result == "Success");
+  }
+  async wikiSendCargoQuery(params) {
+    params.action = "cargoquery";
+    params.format = "json";
+    let reply = await this.wikiSendRequest(params);
+    if (typeof reply.warnings != "undefined") {
+      if (typeof reply.warnings.cargoquery != "undefined") {
+        if ((typeof reply.warnings.cargoquery['*'] != "undefined")
+            && reply.warnings.cargoquery['*'].match(/may not be over 500/i)) {
+          // Limited by 500 rows per query.
+          this.wikiLimit = 500;
+        }
+      }
+    }
+    if (typeof reply.error != "undefined") {
+      throw (reply.error.code+": "+reply.error.info);
+    }
+    return reply.cargoquery;
+  }
+  async wikiSendRequest(params) {
+    let url = "https://pathofexile.gamepedia.com/api.php";
+    let promise = new Promise((resolve, reject) => {
+      request({
+        'method': 'POST',
+        'uri': url,
+        'form': params,
+        'jar': true,
+        'json': true,
+      }, (error, response, body) => {
+          if (error) reject(error);
+          if (response.statusCode != 200) {
+              reject('Invalid status code <' + response.statusCode + '>');
+          }
+          resolve(body);
+      });
+    });
+    return promise;
+  }
+  async fetchWikiTable(params, callback, ...callbackParams) {
+    let queryResult = null;
+    params.offset = 0;
+    params.limit = this.wikiLimit;
+    while (true) {
+      // Send query
+      queryResult = await this.wikiSendCargoQuery(params);
+      // Process results
+      for (let i = 0; i < queryResult.length; i++) {
+        callback(queryResult[i].title, params.offset + i, ...callbackParams);
+      }
+      // Update offset and limit
+      params.offset += queryResult.length;
+      params.limit = this.wikiLimit;
+      if (queryResult.length < this.wikiLimit) {
+        // Exit when all entries have been processed
+        break;
+      } else {
+        // Throttle a bit.
+        await this.wait(200);
+      }
+    }
+  }
+  async fetchItems(callback, ...callbackParams) {
+    return await this.fetchWikiTable({
+      fields: [
+        '_pageID=page_id',
+        'alternate_art_inventory_icons',
+        'base_item', 'base_item_id', 'base_item_page',
+        'cannot_be_traded_or_modified',
+        'class', 'class_id',
+        'description',
+        'drop_areas', 'drop_enabled', 'drop_leagues', 'drop_level', 'drop_level_maximum',
+        'drop_rarities', 'drop_rarities_ids', 'drop_text',
+        'explicit_stat_text', 'flavour_text', 'frame_type', 'help_text', 'icon',
+        'implicit_stat_text', 'inventory_icon', 'is_corrupted', 'is_corrupted', 'is_relic', 'metadata_id',
+        'name', 'name_list', 'quality', 'rarity', 'rarity_id', 'release_version', 'removal_version',
+        /*
+        'required_dexterity', 'required_dexterity_range_average', 'required_dexterity_range_colour',
+        'required_dexterity_range_maximum', 'required_dexterity_range_minimum', 'required_dexterity_range_text',
+        'required_intelligence', 'required_intelligence_range_average', 'required_intelligence_range_colour',
+        'required_intelligence_range_maximum', 'required_intelligence_range_minimum', 'required_intelligence_range_text',
+        'required_level', 'required_level_base', 'required_level_range_average', 'required_level_range_colour',
+        'required_level_range_maximum', 'required_level_range_minimum',  'required_level_range_text',
+        'required_strength', 'required_strength_range_average', 'required_strength_range_colour',
+        'required_strength_range_maximum', 'required_strength_range_minimum',  'required_strength_range_text',
+        */
+        'size_x', 'size_y', 'stat_text', 'supertype', 'tags'
+      ].join(","),
+      tables: 'items'
+    }, callback, ...callbackParams);
+  }
+  async fetchItemMods(callback, ...callbackParams) {
+    return await this.fetchWikiTable({
+      fields: [
+        '_pageID=page_id',
+        'id',
+        'is_implicit', 'is_random',
+        'text'
+      ].join(","),
+      tables: 'item_mods'
+    }, callback, ...callbackParams);
+  }
+  async fetchItemStats(callback, ...callbackParams) {
+    return await this.fetchWikiTable({
+      fields: [
+        '_pageID=page_id',
+        'id',
+        'is_implicit', 'is_random',
+        'avg', 'min', 'max'
+      ].join(","),
+      tables: 'item_stats'
+    }, callback, ...callbackParams);
+  }
+  async fetchMods(callback, ...callbackParams) {
+    return await this.fetchWikiTable({
+      fields: [
+        '_pageID=page_id',
+        'id', 'domain', 'generation_type',
+        'granted_buff_id', 'granted_buff_value', 'granted_skill',
+        'mod_group', 'mod_type',
+        'name', 'required_level', 'stat_text', 'stat_text_raw', 'tags', 'tier_text'
+      ].join(","),
+      tables: 'mods'
+    }, callback, ...callbackParams);
+  }
+  async fetchModStats(callback, ...callbackParams) {
+    return await this.fetchWikiTable({
+      fields: [
+        '_pageID=page_id',
+        'id', 'min', 'max'
+      ].join(","),
+      tables: 'mod_stats'
+    }, callback, ...callbackParams);
+  }
+  async fetchSpawnWeights(callback, ...callbackParams) {
+    return await this.fetchWikiTable({
+      fields: [
+        '_pageID=page_id',
+        'ordinal',
+        'tag',
+        'weight'
+      ].join(","),
+      tables: 'spawn_weights'
+    }, callback, ...callbackParams);
+  }
+  async updateApiData(dataType) {
+    let url = "https://www.pathofexile.com/api/trade/data/"+dataType;
+    let promise = new Promise((resolve, reject) => {
+      request({
+        'method': 'GET',
+        'uri': url,
+        'json': true,
+      }, (error, response, body) => {
+          if (error) reject(error);
+          if (response.statusCode != 200) {
+              reject('Invalid status code <' + response.statusCode + '>');
+          }
+          resolve(body);
+      });
+    });
+    return promise;
+  }
+  async updateWikiLogin(entry) {
+    let loginName = config.get("poe-data-login");
+    let loginPass = config.get("poe-data-pass");
+    // Login if login information was provided
+    if ((loginName != "") && (loginPass != "") && (this.wikiLoginToken === null)) {
+      let updateText = "Updating poe data (login)";
+      // Update status text
+      entry.setTitle(updateText+".");
+      // Send login
+      await this.wikiSendLogin(loginName, loginPass);
+      // Update status text
+      entry.setTitle(updateText+"..");
+    }
+  }
+  async updateWikiItems(entry) {
+    // Check login
+    await this.updateWikiLogin(entry);
+    // Prepare update text
+    let updateText = "Updating poe data (items)";
+    let updateTextProgress = "";
+    let updateTextAnimation = (entry) => {
+      updateTextProgress += ".";
+      if (updateTextProgress.length > 5) {
+        updateTextProgress = "";
+      }
+      entry.setTitle(updateText+updateTextProgress);
+    };
+    // Query data
+    this.wikiData.items = {
+      byName: {},
+      byId: {}
+    };
+    // -> Items
+    await this.fetchItems((item, index, entry, poedata) => {
+      // Add mod
+      let itemPageId = item.page_id;
+      delete item.page_id;
+      item['description'] = this.decodeHtml(item['description']);
+      item['stat text'] = this.decodeHtml(item['stat text']);
+      item['help text'] = this.decodeHtml(item['help text']);
+      item['flavour text'] = this.decodeHtml(item['flavour text']);
+      item['tags'] = (item['tags'] == "" ? [] : item['tags'].split(","));
+      item['mods'] = [];
+      item['stats'] = [];
+      if (typeof poedata.wikiData.items.byName[item.name] == "undefined") {
+        poedata.wikiData.items.byName[item.name] = [];
+      }
+      poedata.wikiData.items.byName[item.name].push(itemPageId);
+      poedata.wikiData.items.byId[itemPageId] = item;
+      // Loading "animation"
+      if ((index % poedata.wikiLimit) == 0) {
+        updateTextAnimation(entry);
+      }
+    }, entry, this);
+    // -> Item mods
+    await this.fetchItemMods((mod, index, entry, poedata) => {
+      // Add mod
+      let itemPageId = mod.page_id;
+      delete mod.page_id;
+      if (typeof poedata.wikiData.items.byId[itemPageId] != "undefined") {
+        poedata.wikiData.items.byId[itemPageId].mods.push(mod);
+      } else {
+        // Debug code
+        //console.log("Found mod without matching item: "+itemPageId+" -> "+util.inspect(mod));
+      }
+      // Loading "animation"
+      if ((index % poedata.wikiLimit) == 0) {
+        updateTextAnimation(entry);
+      }
+    }, entry, this);
+    // -> Item stats
+    await this.fetchItemStats((stat, index, entry, poedata) => {
+      // Add stat
+      let itemPageId = stat.page_id;
+      delete stat.page_id;
+      if (typeof poedata.wikiData.items.byId[itemPageId] != "undefined") {
+        poedata.wikiData.items.byId[itemPageId].stats.push(stat);
+      } else {
+        // Debug code
+        //console.log("Found stat without matching item: "+itemPageId+" -> "+util.inspect(stat));
+      }
+      // Loading "animation"
+      if ((index % poedata.wikiLimit) == 0) {
+        updateTextAnimation(entry);
+      }
+    }, entry, this);
+  }
+  async updateWikiMods(entry) {
+    // Check login
+    await this.updateWikiLogin(entry);
+    // Prepare update text
+    let updateText = "Updating poe data (mods)";
+    let updateTextProgress = "";
+    let updateTextAnimation = (entry) => {
+      updateTextProgress += ".";
+      if (updateTextProgress.length > 5) {
+        updateTextProgress = "";
+      }
+      entry.setTitle(updateText+updateTextProgress);
+    };
+    // Query data
+    this.wikiData.mods = {
+      byModIdent: {},
+      byDomain: {},
+      byGeneration: {},
+      bySpawnTags: {},
+      byId: {}
+    };
+    // -> Mods
+    await this.fetchMods((mod, index, entry, poedata) => {
+      // Add mod
+      let modPageId = mod.page_id;
+      delete mod.page_id;
+      mod['trade text'] = poedata.getTradeText(mod['stat text raw']);
+      mod['trade limits'] = poedata.getTradeLimits(mod['stat text raw']);
+      mod['trade ids'] = poedata.getTradeIds(mod['trade text']);
+      mod['tags'] = (mod['tags'] == "" ? [] : mod['tags'].split(","));
+      mod['stats'] = [];
+      mod['spawnWeights'] = [];
+      poedata.wikiData.mods.byId[modPageId] = mod;
+      poedata.wikiData.mods.byModIdent[mod.id] = modPageId;
+      // Domain lookup
+      if (typeof poedata.wikiData.mods.byDomain[mod['domain']] == "undefined") {
+        poedata.wikiData.mods.byDomain[mod['domain']] = [];
+      }
+      poedata.wikiData.mods.byDomain[mod['domain']].push(modPageId);
+      // Generation lookup
+      if (typeof poedata.wikiData.mods.byGeneration[mod['generation type']] == "undefined") {
+        poedata.wikiData.mods.byGeneration[mod['generation type']] = [];
+      }
+      poedata.wikiData.mods.byGeneration[mod['generation type']].push(modPageId);
+      // Loading "animation"
+      if ((index % poedata.wikiLimit) == 0) {
+        updateTextAnimation(entry);
+      }
+    }, entry, this);
+    // -> Mod stats
+    updateText = "Updating poe data (mod stats)";
+    await this.fetchModStats((stat, index, entry, poedata) => {
+      // Add mod
+      let modPageId = stat.page_id;
+      delete stat.page_id;
+      if (typeof poedata.wikiData.mods.byId[modPageId] != "undefined") {
+        poedata.wikiData.mods.byId[modPageId].stats.push(stat);
+      } else {
+        //console.log("Found stat without matching mod: "+modPageId+" -> "+util.inspect(stat));
+      }
+      // Loading "animation"
+      if ((index % poedata.wikiLimit) == 0) {
+        updateTextAnimation(entry);
+      }
+    }, entry, this);
+    // -> Mod spawn weights
+    updateText = "Updating poe data (mod spawns)";
+    await this.fetchSpawnWeights((spawnWeight, index, entry, poedata) => {
+      // Add mod
+      let modPageId = spawnWeight.page_id;
+      delete spawnWeight.page_id;
+      if (typeof poedata.wikiData.mods.byId[modPageId] != "undefined") {
+        poedata.wikiData.mods.byId[modPageId].spawnWeights.push(spawnWeight);
+        if (spawnWeight.weight > 0) {
+          if (typeof poedata.wikiData.mods.bySpawnTags[spawnWeight.tag] == "undefined") {
+            poedata.wikiData.mods.bySpawnTags[spawnWeight.tag] = [];
+          }
+          poedata.wikiData.mods.bySpawnTags[spawnWeight.tag].push({
+            modId: modPageId, ordinal: spawnWeight.ordinal, weight: spawnWeight.weight
+          });
+        }
+      } else {
+        //console.log("Found spawnWeight without matching mod: "+modPageId+" -> "+util.inspect(spawnWeight));
+      }
+      // Loading "animation"
+      if ((index % poedata.wikiLimit) == 0) {
+        updateTextAnimation(entry);
+      }
+    }, entry, this);
+  }
+  update() {
+    var poeDataUpdateEntry = new TextEntry("Updating poe data (core)...");
+    poeDataUpdateEntry.add();
+    poeDataUpdateEntry.setCloseable(false);
+    this.refresh(poeDataUpdateEntry).then(() => {
+      poeDataUpdateEntry.setTitle("Updated poe-data successfully!");
+      poeDataUpdateEntry.setIcon("fa-check-circle green");
+      poeDataUpdateEntry.setCloseable(true);
+      poeDataUpdateEntry.enableAutoClose(10);
+    })
+    .catch((error) => {
+      log.warn("Failed updating poe-data, " + error);
+      poeDataUpdateEntry.setTitle("Updating poe-data failed!");
+      poeDataUpdateEntry.setText("Please check the log file for more information.");
+      poeDataUpdateEntry.setCloseable(true);
+      poeDataUpdateEntry.setIcon("fa-exclamation-circle red");
+      poeDataUpdateEntry.addLogfileButton();
+    })
+    .then(() => {
+      GUI.toggleMenuButtonColor("update", true);
+    });
+  }
+  async refresh(entry) {
+    this.updateActive = true;
+    // Cache lifetime in minutes
+    let cacheLifetime = 60 * 24 * config.get("poeDataInterval");
+    // Check cache for trade data
+    let cacheFileTrade = this.getCacheFilename("trade");
+    if (!this.isCacheValid(cacheFileTrade, cacheLifetime)) {
+      let promiseLeagues = this.updateApiData("leagues");
+      let promiseStatic = this.updateApiData("static");
+      let promiseStats = this.updateApiData("stats");
+      this.handleLeagues(await promiseLeagues);
+      this.handleStatic(await promiseStatic);
+      this.handleStats(await promiseStats);
+      this.writeCache("trade");
+    }
+    // Check cache for wiki data (items)
+    let cacheFileWikiItems = this.getCacheFilename("wiki-items");
+    if (!this.isCacheValid(cacheFileWikiItems, cacheLifetime)) {
+      await this.updateWikiItems(entry);
+      this.writeCache("wiki-items");
+    }
+    // Check cache for wiki data (mods)
+    let cacheFileWikiMods = this.getCacheFilename("wiki-mods");
+    if (!this.isCacheValid(cacheFileWikiMods, cacheLifetime)) {
+      await this.updateWikiMods(entry);
+      this.writeCache("wiki-mods");
+    }
+    this.updateActive = false;
+  }
+  wait(ms) {
+    return new Promise(resolve => {
+        setTimeout(resolve,ms)
+    });
+  }
+  isCacheValid(cacheFile, cacheLifetime) {
+    if (fs.existsSync(cacheFile)) {
+      if (cacheLifetime == 0) {
+        return true;
+      } else {
+        let now = Date.now();
+        let cacheStat = fs.statSync(cacheFile);
+        let cacheAge = (now - cacheStat.mtimeMs) / 1000 / 60; // File age in minutes
+        if (cacheAge < cacheLifetime) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+  isUpdating() {
+    return this.updateActive;
+  }
+  getCacheDirectory() {
+    if(os.platform() === "linux") {
+      return path.join(os.homedir(), "/.config/XenonTrade/poe-data");
+    } else {
+      return path.join(os.homedir(), "/AppData/Roaming/XenonTrade/poe-data");
+    }
+  }
+  getCacheFilename(type) {
+    switch (type) {
+      default:
+        return path.join(this.getCacheDirectory(), "poe-data-"+type+".json.gz");
+    }
+  }
+  getTradeText(rawText) {
+    return this.decodeHtml(rawText).replace(/\+?\([0-9\-\.]+\)/g, "#");
+  }
+  getTradeLimits(rawText) {
+    let matchLimits = false;
+    let lines = this.decodeHtml(rawText).split("\n");
+    let result = [];
+    for (let l = 0; l < lines.length; l++) {
+      let resultLine = [];
+      let regExpLimits = /\+?\(([0-9\-\.]+)\)/g;
+      while (matchLimits = regExpLimits.exec(lines[l])) {
+        resultLine.push(matchLimits[1].split("-"));
+      }
+      result.push(resultLine);
+    }
+    return result;
+  }
+  getTradeIds(text) {
+    if (text == "") {
+      return [];
+    }
+    let tradeIds = [];
+    let lines = text.split("\n");
+    for (let l = 0; l < lines.length; l++) {
+      let lineTradeIds = [];
+      // Look for exact matches
+      for (let statType in this.tradeData.stats) {
+        for (let statId in this.tradeData.stats[statType]) {
+          if (lines[l] == this.tradeData.stats[statType][statId]) {
+            lineTradeIds.push(statId);
+          }
+        }
+      }
+      if (lineTradeIds.length == 0) {
+        // Check more tolerant matches
+        let tradeRegExpText = this.escapeRegExpString(lines[l])
+          .replace(/(\\\+)?([0-9]+)/g, "(\\+?#|\\+?$2)")
+          .replace(/reduced/g, "(increased|reduced)")
+          .replace(/seconds?/g, "seconds?");
+        let tradeRegExp = new RegExp("^"+tradeRegExpText+"$", "i");
+        for (let statType in this.tradeData.stats) {
+          for (let statId in this.tradeData.stats[statType]) {
+            if (this.tradeData.stats[statType][statId].match(tradeRegExp)) {
+              lineTradeIds.push(statId);
+            }
+          }
+        }
+      }
+      tradeIds.push(lineTradeIds);
+    }
+    return tradeIds;
+  }
+  readCache(type) {
+    if (typeof type == "undefined") {
+      // Read everything from cache
+      this.readCache("trade");
+      this.readCache("wiki-items");
+      this.readCache("wiki-mods");
+    } else {
+      // Read specific type from cache
+      let cacheFile = this.getCacheFilename(type);
+      if (!fs.existsSync(cacheFile)) {
+        // Cache file does not exist! Skip.
+        return;
+      }
+      let cacheContent = this.readCacheRaw(cacheFile);
+      switch (type) {
+        case "trade":
+          this.tradeData = JSON.parse(cacheContent);
+          break;
+        case "wiki-items":
+          this.wikiData.items = JSON.parse(cacheContent);
+          break;;
+        case "wiki-mods":
+          this.wikiData.mods = JSON.parse(cacheContent);
+          break;
+      }
+    }
+  }
+  readCacheRaw(cacheFile) {
+    let cacheContent = fs.readFileSync(cacheFile);
+    return zlib.gunzipSync(cacheContent).toString();
+  }
+  writeCache(type) {
+    if (typeof type == "undefined") {
+      // Write everything into cache
+      this.writeCache("trade");
+      this.writeCache("wiki-items");
+      this.writeCache("wiki-mods");
+    } else {
+      // Create cache directory if it does not exist
+      let cacheDir = this.getCacheDirectory();
+      if (!fs.existsSync( cacheDir )) {
+        fs.mkdir(cacheDir, { recursive: true });
+      }
+      // Write specific type into cache
+      let cacheFile = this.getCacheFilename(type);
+      switch (type) {
+        case "trade":
+          this.writeCacheRaw( cacheFile, JSON.stringify(this.tradeData) );
+          break;
+        case "wiki-items":
+          this.writeCacheRaw( cacheFile, JSON.stringify(this.wikiData.items) );
+          break;
+        case "wiki-mods":
+          this.writeCacheRaw( cacheFile, JSON.stringify(this.wikiData.mods) );
+          break;
+      }
+    }
+  }
+  writeCacheRaw(cacheFile, cacheContent) {
+    let cacheContentBuffer = new Buffer(cacheContent, "utf-8");
+    let cacheContentGzip = zlib.gzipSync(cacheContentBuffer);
+    fs.writeFileSync( cacheFile, cacheContentGzip );
+  }
+}
+
+module.exports = PoeData;

--- a/src/modules/poetrade.js
+++ b/src/modules/poetrade.js
@@ -1,0 +1,383 @@
+const request = require("request-promise-native");
+
+const modPseudoMappings = require("../resource/modPseudoMappings");
+
+class PoeTrade {
+  /**
+  * Requests item price prediction from pathofexile.com/trade/
+  *
+  * @param {Item} itemData Item text copied from Path of Exile
+  * @returns {Promise}
+  * @fulfil {Object} - Object containing the requested item encoded in base64 and the result
+  * @reject {Error} - The `error.message` contains information about why the promise was rejected
+  */
+  static request(itemData) {
+    return new Promise(function(resolve, reject) {
+      var url = "https://www.pathofexile.com/api/trade/search/"+config.get("league");
+      var parameters = PoeTrade.getSearchQuery(itemData);
+      var options = {
+        method: 'POST',
+        uri: url,
+        body: parameters,
+        json: true // Automatically stringifies the body to JSON
+      };
+
+      request(url, options)
+        .then((response) => {
+          PoeTrade.requestItems(response.id, response.result.slice(0, 10))
+            .then((summary) => {
+              resolve(summary);
+            })
+            .catch((error) => {
+              reject(error);
+            });
+        })
+        .catch((error) => {
+          log.warn("Request to pathofexile.com/trade/ failed. (Search submit)\n" + JSON.stringify(error, null, 4));
+          reject(new Error("Request to <b>pathofexile.com/trade/</b> failed. (Search submit)" + error.error));
+        });
+    });
+  }
+
+  static requestItems(searchId, itemIds) {
+    return new Promise(async function(resolve, reject) {
+      if (itemIds.length == 0) {
+        resolve( PoeTrade.getSearchResultSummary(searchId, null) );
+        return;
+      }
+      let url = "https://www.pathofexile.com/api/trade/fetch/"+itemIds.join(",")+"?query="+searchId;
+      var options = {
+        method: 'GET',
+        uri: url,
+        json: true // Automatically stringifies the body to JSON
+      };
+
+      request(url, options)
+        .then((response) => {
+          try {
+            resolve( PoeTrade.getSearchResultSummary(searchId, response) );
+          } catch(error) {
+            reject(error);
+          }
+        })
+        .catch((error) => {
+          log.warn("Request to pathofexile.com/trade/ failed. (Search fetch)\n" + JSON.stringify(error, null, 4));
+          reject(new Error("Request to <b>pathofexile.com/trade/</b> failed. (Search fetch)" + error.error));
+        });
+    });
+  }
+
+  static getSearchResultSummary(searchId, response) {
+    let result = {
+      searchUrl: "https://www.pathofexile.com/trade/search/"+config.get("league")+"/"+searchId,
+      priceList: [],
+      price: { currency: "chaos", min: null, max: null, avg: 0 }
+    };
+    if (response === null) {
+      result.price.min = "???";
+      result.price.max = "???";
+      return result;
+    }
+    let priceEx = PoeTrade.getCurrencyChaosValue("exa", 1);
+    let priceSum = 0;
+    for (let i = 0; i < response.result.length; i++) {
+      let item = response.result[i];
+      if ((typeof item.listing == "undefined") || (typeof item.listing.price == "undefined")
+          || (item.listing.price == null) || (typeof item.listing.price.amount == "undefined")) {
+        continue;
+      }
+      let priceChaos = PoeTrade.getCurrencyChaosValue(item.listing.price.currency, item.listing.price.amount);
+      if (priceChaos !== null) {
+        priceSum += priceChaos;
+        if ((result.price.min === null) || (result.price.min > priceChaos)) {
+          result.price.min = priceChaos;
+        }
+        if ((result.price.max === null) || (result.price.max < priceChaos)) {
+          result.price.max = priceChaos;
+        }
+        result.priceList.push(priceChaos);
+      }
+    }
+    if (result.priceList.length > 0) {
+      result.price.avg = priceSum / result.priceList.length;
+    } else {
+      result.price.min = 0;
+      result.price.max = 0;
+    }
+    if (result.price.min >= priceEx) {
+      result.price.currency = "exa";
+      result.price.avg = Math.round(result.price.avg * 100 / priceEx) / 100;
+      result.price.min = Math.round(result.price.min * 100 / priceEx) / 100;
+      result.price.max = Math.round(result.price.max * 100 / priceEx) / 100;
+    }
+    return result;
+  }
+
+  static getCurrencyChaosValue(currency, amount) {
+    if (currency == "chaos") {
+      return amount;
+    }
+    let currencyName = poeData.getCurrencyName(currency);
+    let currencyList = ninjaAPI.data[config.get("league")]['Currency'];
+    for (let i = 0; i < currencyList.length; i++) {
+      if (currencyList[i].currencyTypeName == currencyName) {
+        return currencyList[i].chaosEquivalent * amount;
+      }
+    }
+    return null;
+  }
+
+  static getSearchQuery(itemData) {
+    let request = {
+      query: {
+        filters: {},
+        stats: [],
+        status: { option: "online" }
+      },
+      sort: { price: "asc" }
+    };
+    let pseudoMods = {};
+    // Search sockets and links
+    if (itemData.getMaxLinkLength() > 3) {
+      PoeTrade.addFilterToQuery(request, "socket_filters", "sockets", {
+        min: itemData.getSocketCount(),
+        max: itemData.getSocketCountMax()
+      });
+      PoeTrade.addFilterToQuery(request, "socket_filters", "links", {
+        min: itemData.getMaxLinkLength()
+      });
+    }
+    // Search for weapon values
+    if (itemData.getDPS() > 0) {
+      PoeTrade.addFilterToQuery(request, "weapon_filters", "dps", {
+        min: itemData.getDPS() * 0.9
+      });
+    }
+    // Search for armour values
+    if (itemData.getArmour() > 0) {
+      PoeTrade.addFilterToQuery(request, "armour_filters", "ar", {
+        min: itemData.getArmour() * 0.75
+      });
+    }
+    if (itemData.getEnergyShield() > 0) {
+      PoeTrade.addFilterToQuery(request, "armour_filters", "es", {
+        min: itemData.getEnergyShield() * 0.75
+      });
+    }
+    if (itemData.getEvasion() > 0) {
+      PoeTrade.addFilterToQuery(request, "armour_filters", "ev", {
+        min: itemData.getEvasion() * 0.75
+      });
+    }
+    if (itemData.getBlock() > 0) {
+      PoeTrade.addFilterToQuery(request, "armour_filters", "block", {
+        min: itemData.getBlock() * 0.75
+      });
+    }
+    // Search name
+    let ignoreName = true;
+    let itemRarity = null;
+    switch (itemData.getRarity()) {
+      case "Normal":
+      case "Magic":
+      case "Rare":
+        itemRarity = itemData.getRarity();
+        ignoreName = false;
+        if (itemData.hasTag("weapon") || itemData.hasTag("armour") || itemData.hasTag("quiver")
+            || itemData.hasTag("ring") || itemData.hasTag("belt") || itemData.hasTag("amulet")
+            || itemData.hasTag("jewel")) {
+          ignoreName = true;
+        }
+        break;
+      case "Unique":
+        itemRarity = itemData.getRarity();
+        // Search unique items by name
+        ignoreName = false;
+        break;
+    }
+    if (!ignoreName) {
+      request.query.term = itemData.getName();
+    }
+    // Add implicit if present
+    let implicitMods = itemData.getImplicitMods();
+    for (let i = 0; i < implicitMods.length; i++) {
+      if (!PoeTrade.handleModSpecial(pseudoMods, implicitMods[i], itemData)) {
+        PoeTrade.addModToQuery(request, implicitMods[i]);
+      }
+    }
+    // Add explicits
+    let explicitMods = itemData.getExplicitMods();
+    for (let i = 0; i < explicitMods.length; i++) {
+      if (!PoeTrade.handleModSpecial(pseudoMods, explicitMods[i], itemData)) {
+        PoeTrade.addModToQuery(request, explicitMods[i]);
+      }
+    }
+    // Add pseudo mods
+    for (let pseudoId in pseudoMods) {
+      PoeTrade.addRawModToQuery(request, pseudoMods[pseudoId]);
+    }
+    // Search for item type
+    PoeTrade.addItemCategory(request, itemData);
+    // Search for quality
+    if (itemData.hasTag("gem")) {
+      PoeTrade.addItemQuality(request, itemData);
+    }
+    // Search for rarity
+    if (itemRarity !== null) {
+      PoeTrade.addFilterToQuery(request, "type_filters", "rarity", {
+        option: itemRarity.toLowerCase()
+      });
+    }
+    // Search for corrupted / not corrupted query.filters.misc_filters.filters.corrupted
+    PoeTrade.addFilterToQuery(request, "misc_filters", "corrupted", {
+      option: itemData.isCorrupted()
+    });
+
+    //console.log(require('util').inspect(request, { depth: null }));
+    return request;
+  }
+  static addItemCategory(request, itemData) {
+    let itemCategory = null;
+    if (itemData.hasTag("one_hand_weapon") && !itemData.hasTag("ranged")) {
+      itemCategory = "weapon.onemelee";
+    } else if (itemData.hasTag("two_hand_weapon") && !itemData.hasTag("ranged")) {
+      itemCategory = "weapon.twomelee";
+    } else if (itemData.hasTag("bow")) {
+      itemCategory = "weapon.bow";
+    } else if (itemData.hasTag("wand")) {
+      itemCategory = "weapon.wand";
+    } else if (itemData.hasTag("body_armour")) {
+      itemCategory = "armour.chest";
+    } else if (itemData.hasTag("boots")) {
+      itemCategory = "armour.boots";
+    } else if (itemData.hasTag("gloves")) {
+      itemCategory = "armour.gloves";
+    } else if (itemData.hasTag("helmet")) {
+      itemCategory = "armour.helmet";
+    } else if (itemData.hasTag("shield")) {
+      itemCategory = "armour.shield";
+    } else if (itemData.hasTag("quiver")) {
+      itemCategory = "armour.quiver";
+    } else if (itemData.hasTag("amulet")) {
+      itemCategory = "accessory.amulet";
+    } else if (itemData.hasTag("belt")) {
+      itemCategory = "accessory.belt";
+    } else if (itemData.hasTag("ring")) {
+      itemCategory = "accessory.ring";
+    }
+    if (itemCategory !== null) {
+      PoeTrade.addFilterToQuery(request, "type_filters", "category", {
+        option: itemCategory
+      });
+    }
+  }
+  static addItemQuality(request, itemData) {
+    PoeTrade.addFilterToQuery(request, "misc_filters", "quality", {
+      min: Math.max(0, itemData.getQuality() - 1),
+      max: (itemData.getQuality() > 0 ? itemData.getQuality() + 1 : 0)
+    });
+  }
+  static addFilterToQuery(request, filterBase, filterField, filterValue) {
+    if (typeof request.query.filters[filterBase] == "undefined") {
+      request.query.filters[filterBase] = {};
+    }
+    if (typeof request.query.filters[filterBase].filters == "undefined") {
+      request.query.filters[filterBase].filters = {};
+    }
+    request.query.filters[filterBase].filters[filterField] = filterValue;
+  }
+  static addModToQuery(request, itemMod, filterType, filterIndex) {
+    let filters = PoeTrade.getModFilters(itemMod);
+    for (let i = 0; i < filters.length; i++) {
+      this.addRawModToQuery(request, filters[i], filterType, filterIndex);
+    }
+  }
+  static addRawModToQuery(request, itemModFilter, filterType, filterIndex) {
+    if (itemModFilter === null) {
+      return;
+    }
+    // Default values
+    if (typeof filterType == "undefined") {
+      filterType = "and";
+    }
+    if (typeof filterIndex == "undefined") {
+      filterIndex = 0;
+    }
+    // Add to form
+    if ((filterIndex !== null) && (typeof request.query.stats[filterIndex] == "undefined")) {
+      filterIndex = null;
+    }
+    if (filterIndex !== null) {
+      request.query.stats[filterIndex].filters.push(itemModFilter);
+    } else {
+      request.query.stats.push({
+        filters: [ itemModFilter ],
+        type: filterType
+      });
+    }
+  }
+  static getModFilters(itemMod) {
+    // Get filter values
+    let statIds = itemMod.getTradeIds();
+    let filters = [];
+    for (let s = 0; s < statIds.length; s++) {
+      if (statIds[s] === null) {
+        continue;
+      }
+      let min = itemMod.getValueMin(s);
+      let max = itemMod.getValueMax(s);
+      let avg = itemMod.getValueAvg(s);
+      // Build filter
+      let filter = { id: statIds[s] };
+      if ((min !== null) && (max !== null) && (avg !== null)) {
+        if (avg == max) {
+          filter.value = { min: avg };
+        } else {
+          let range = max - min;
+          filter.value = { 
+            min: Math.max(min, avg - range * 0.1)
+          };
+        }
+      }      
+      filters.push(filter);
+    }
+    return filters;
+  }
+  static handleModSpecial(pseudoMods, itemMod, item) {
+    let modGroup = itemMod.getGroup();
+    let itemTags = item.getTags();
+    let pseudoId = false;
+    if (typeof modPseudoMappings["mod group"][modGroup] != "undefined") {
+      pseudoId = modPseudoMappings["mod group"][modGroup];
+    }
+    for (let t = 0; t < itemTags.length; t++) {
+      let filterMods = modPseudoMappings["item tag"][ itemTags[t] ];
+      if ((typeof filterMods != "undefined") && (typeof filterMods[modGroup] != "undefined")) {
+        pseudoId = filterMods[modGroup];
+      }
+    }
+    if (pseudoId !== false) {
+      if (pseudoId !== null) {
+        let pseudoIds = (typeof pseudoId == "string" ? [pseudoId] : pseudoId);
+        for (let i = 0; i < pseudoIds.length; i++) {
+          pseudoId = pseudoIds[i];
+          if (pseudoId === null) {
+            continue;
+          }
+          if (typeof pseudoMods[pseudoId] == "undefined") {
+            pseudoMods[pseudoId] = { id: pseudoId, value: { min: 0 } };
+          }
+          if (itemMod.getValueAvg(i) == itemMod.getValueMax(i)) {
+            pseudoMods[pseudoId].value.min += itemMod.getValueAvg(i);
+          } else {
+            pseudoMods[pseudoId].value.min += itemMod.getValueMin(i);
+          }
+        }
+      }
+      return true;
+    }
+    return false
+  }
+}
+
+module.exports = PoeTrade;

--- a/src/modules/pricecheck.js
+++ b/src/modules/pricecheck.js
@@ -1,10 +1,12 @@
 const PoePrices = require("./poeprices.js");
+const PoeTrade = require("./poetrade.js");
 const Parser = require("./parser.js");
 
 const ItemEntry = require("./entries/item-entry.js");
 const CurrencyEntry = require("./entries/currency-entry.js");
 const TextEntry = require("./entries/text-entry.js");
 const RareItemEntry = require("./entries/rare-item-entry.js");
+const PoeTradeEntry = require("./entries/poe-trade-entry.js");
 
 class Pricecheck {
   /**
@@ -19,13 +21,121 @@ class Pricecheck {
     // If identified and Path of Exile item data...
     if(parser.isPathOfExileData() && parser.isIdentified() === true) {
       if(itemType === "Rare") {
-        Pricecheck._getRarePrice(parser);
-      } else if(itemType !== "Magic" && !ninjaAPI.isUpdating()) {
-        Pricecheck._getNinjaPrice(parser);
-      } else {
-        GUI.flashIcon("fas fa-exclamation-circle red");
+        Pricecheck._getRarePrice(parser, config.get("provider_rare"));
+      } else if (itemType === "Currency" || itemType === "Fragment") {
+        Pricecheck._getCurrencyPrice(parser, config.get("provider_currency"));
+      } else if (itemType !== "Magic") {
+        Pricecheck._getOtherPrice(parser, config.get("provider_others"));
       }
     }
+  }
+
+  /**
+  * Gets the item price from the given provider
+  *
+  * @param {Parser} parser Parser containing the item clipboard
+  * @param {string} provider Provider used for checking the price
+  */
+  static _getRarePrice(parser, provider) {
+
+    switch (provider) {
+      case "poeprices":
+        // poeprices.info
+        var entry = new TextEntry("Getting price prediction...", {closeable: false});
+        entry.add();
+        PoePrices.request(parser.getItemText())
+        .then((result) => {
+          entry.close();
+          new RareItemEntry(result, parser).add();
+        })
+        .catch((error) => {
+          entry.setTitle("Failed to get price prediction");
+          entry.setText(error.message);
+          entry.setIcon("fa-exclamation-triangle yellow");
+          entry.setCloseable(true);
+          entry.addLogfileButton();
+        });
+        break;
+      case "poetrade":
+        // pathofexile.com/trade
+        if (ninjaAPI.isUpdating() || poeData.isUpdating()) {
+          GUI.flashIcon("fas fa-exclamation-circle red");
+          return;
+        }
+        Pricecheck._getPoeTradePrice(parser)
+        break;
+    }
+
+  }
+
+  /**
+  * Gets the item price from the given provider
+  *
+  * @param {Parser} parser Parser containing the item clipboard
+  * @param {string} provider Provider used for checking the price
+  */
+  static _getCurrencyPrice(parser, provider) {
+      switch (provider) {
+        case "poeninja":
+          // poe.ninja
+          if (ninjaAPI.isUpdating()) {
+            GUI.flashIcon("fas fa-exclamation-circle red");
+            return;
+          }
+          Pricecheck._getNinjaPrice(parser)
+          break;
+      }
+  }
+
+  /**
+  * Gets the item price from the given provider
+  *
+  * @param {Parser} parser Parser containing the item clipboard
+  * @param {string} provider Provider used for checking the price
+  */
+  static _getOtherPrice(parser, provider) {
+      switch (provider) {
+        case "poeninja":
+          // poe.ninja
+          if (ninjaAPI.isUpdating()) {
+            GUI.flashIcon("fas fa-exclamation-circle red");
+            return;
+          }
+          Pricecheck._getNinjaPrice(parser)
+          break;
+        case "poetrade":
+          // pathofexile.com/trade
+          if (ninjaAPI.isUpdating() || poeData.isUpdating()) {
+            GUI.flashIcon("fas fa-exclamation-circle red");
+            return;
+          }
+          Pricecheck._getPoeTradePrice(parser)
+          break;
+      }
+  }
+
+  /**
+  * Gets the item based on the parsed data from pathofexile.com/trade
+  *
+  * @param {Parser} parser Parser containing the item clipboard
+  */
+  static _getPoeTradePrice(parser) {
+    var entry = new TextEntry("Getting price prediction...", {closeable: false});
+    entry.add();
+    PoeTrade.request(parser.item)
+      .then((result) => {
+        entry.close();
+        new PoeTradeEntry(result, parser).add();
+      })
+      .catch((error) => {
+        console.error(error.message);
+        console.log(error.stack);
+        entry.setTitle("Failed to get price prediction");
+        entry.setText(error.message);
+        entry.setIcon("fa-exclamation-triangle yellow");
+        entry.setCloseable(true);
+        entry.addLogfileButton();
+      });
   }
 
   /**
@@ -45,29 +155,6 @@ class Pricecheck {
     } else {
       new TextEntry("No data", "There's no data for " + config.get("league") + ". You should update before attempting to price check another item.", {icon: "fa-exclamation-triangle yellow", timeout: 10}).add();
     }
-  }
-
-  /**
-  * Gets the item price from poeprices
-  *
-  * @param {Parser} parser Parser containing the item clipboard
-  */
-  static _getRarePrice(parser) {
-    var entry = new TextEntry("Getting price prediction...", {closeable: false});
-    entry.add();
-
-    PoePrices.request(parser.getItemText())
-    .then((result) => {
-      entry.close();
-      new RareItemEntry(result, parser).add();
-    })
-    .catch((error) => {
-      entry.setTitle("Failed to get price prediction");
-      entry.setText(error.message);
-      entry.setIcon("fa-exclamation-triangle yellow");
-      entry.setCloseable(true);
-      entry.addLogfileButton();
-    });
   }
 
   /**

--- a/src/resource/modPseudoMappings.json
+++ b/src/resource/modPseudoMappings.json
@@ -1,0 +1,110 @@
+{
+  "item tag": {
+    "default": {
+      "Strength": null,
+      "Dexterity": null,
+      "Intelligence": null,
+      "StrengthDexterity": null,
+      "StrengthIntelligence": null,
+      "DexterityIntelligence": null,
+      "AllAttributes": null,
+      "LifeRegeneration": null,
+      "ManaRegeneration": null,
+      "AttackerTakesDamageNoRange": null,
+      "ItemFoundRarityIncrease": null,
+      "ItemFoundRarityIncreasePrefix": null,
+      "ChanceToDodge": null
+    },
+    "armour": {
+      "DefencesPercent": null, 
+      "BaseLocalDefences": null, 
+      "DefencesPercentAndStunRecovery": null, 
+      "IncreasedEvasionRating": null, 
+      "IncreasedEnergyShield": null
+    },
+    "wand": {
+      "IncreasedMana": null,
+      "CriticalStrikeMultiplier": null
+    },
+    "weapon": {
+      "FireResistance": null,
+      "ColdResistance": null,
+      "LightningResistance": null,
+      "ChaosResistance": null,
+      "AllResistances": null,
+      "AddedFireDamageSpellsAndAttacks": null,
+      "AddedColdDamageToSpellsAndAttacks": null,
+      "AddedLightningDamageSpellsAndAttacks": null,
+      "PhysicalDamage": null,
+      "FireDamage": null,
+      "ColdDamage": null,
+      "LightningDamage": null,
+      "ChaosDamage": null,
+      "AddedPhysicalSuffix": null,
+      "AddedFireSuffix": null,
+      "AddedColdSuffix": null,
+      "AddedLightningSuffix": null,
+      "AddedChaosSuffix": null,
+      "IncreasedAccuracy": null,
+      "LocalIncreasedPhysicalDamagePercentAndAccuracyRating": null,
+      "IncreasedMana": null,
+      "IncreasedLife": null,
+      "IncreasedEnergyShield": null,
+      "SpellDamageAndMana": [
+        "pseudo.pseudo_increased_spell_damage",
+        null
+      ]
+    }
+  },
+  "mod group": {
+    "FireResistance": "pseudo.pseudo_total_elemental_resistance",
+    "ColdResistance": "pseudo.pseudo_total_elemental_resistance",
+    "LightningResistance": "pseudo.pseudo_total_elemental_resistance",
+    "ChaosResistance": "pseudo.pseudo_total_elemental_resistance",
+    "AllResistances": "pseudo.pseudo_total_all_elemental_resistances",
+
+    "IncreasedLife": "pseudo.pseudo_total_life",
+    "IncreasedMana": "pseudo.pseudo_total_mana",
+    "IncreasedEnergyShield": "pseudo.pseudo_total_energy_shield",
+
+    "IncreasedAttackSpeed": "pseudo.pseudo_total_attack_speed",
+    "IncreasedCastSpeed": "pseudo.pseudo_total_cast_speed",
+    "MovementVelocity": "pseudo.pseudo_increased_movement_speed",
+
+    "LocalPhysicalDamagePercent": "pseudo.pseudo_increased_physical_damage",
+    
+    "SpellDamage": "pseudo.pseudo_increased_spell_damage",
+    "SpellDamageAndMana": [
+      "pseudo.pseudo_increased_spell_damage",
+      "pseudo.pseudo_total_mana"
+    ],
+    "WeaponCasterDamagePrefix": "pseudo.pseudo_increased_spell_damage",
+
+    "AddedFireDamageSpellsAndAttacks": "pseudo.pseudo_adds_damage",
+    "AddedColdDamageToSpellsAndAttacks": "pseudo.pseudo_adds_damage",
+    "AddedLightningDamageSpellsAndAttacks": "pseudo.pseudo_adds_damage",
+
+    "PhysicalDamage": null,
+    "FireDamage": null,
+    "ColdDamage": null,
+    "LightningDamage": null,
+    "ChaosDamage": "pseudo.pseudo_adds_chaos_damage_to_attacks",
+    "AddedPhysicalSuffix": null,
+    "AddedFireSuffix": null,
+    "AddedColdSuffix": null,
+    "AddedLightningSuffix": null,
+    "AddedChaosSuffix": "pseudo.pseudo_adds_chaos_damage_to_attacks",
+    
+    "SpellAddedPhysicalDamage": "pseudo.pseudo_adds_damage_to_spells",
+    "SpellAddedElementalDamage": "pseudo.pseudo_adds_damage_to_spells",
+    "SpellAddedChaosDamage": "pseudo.pseudo_adds_damage_to_spells",
+
+    "ElementalDamagePercent": "pseudo.pseudo_increased_elemental_damage",
+
+    "ItemFoundRarityIncrease": "pseudo.pseudo_increased_rarity",
+    "ItemFoundRarityIncreasePrefix": "pseudo.pseudo_increased_rarity",
+    "IncreaseSocketedGemLevel": "pseudo.pseudo_total_additional_gem_levels",
+    
+    "BaseLocalDefencesAndLife": [ null, "pseudo.pseudo_total_life" ]
+  }
+}

--- a/src/resource/parserBlockTypes.json
+++ b/src/resource/parserBlockTypes.json
@@ -1,0 +1,66 @@
+{
+  "name-rarity": {
+    "regex": "^Rarity: (.+)$",
+    "type": "name"
+  },
+  "requirements": {
+    "regex": "^Requirements:$",
+    "type": "requirements"
+  },
+  "properties-quality": {
+    "regex": "^Quality: (.+)$",
+    "type": "properties"
+  },
+  "properties-evasion": {
+    "regex": "^Evasion Rating: (.+)$",
+    "type": "properties"
+  },
+  "properties-energyShield": {
+    "regex": "^Energy Shield: (.+)$",
+    "type": "properties"
+  },
+  "properties-armour": {
+    "regex": "^Armour: (.+)$",
+    "type": "properties"
+  },
+  "properties-physicalDamage": {
+    "regex": "^Physical Damage: (.+)$",
+    "type": "properties"
+  },
+  "properties-criticalStrikeChance": {
+    "regex": "^Critical Strike Chance: (.+)$",
+    "type": "properties"
+  },
+  "properties-attacksPerSecond": {
+    "regex": "^Attacks per Second: (.+)$",
+    "type": "properties"
+  },
+  "properties-weaponRange": {
+    "regex": "^Weapon Range: (.+)$",
+    "type": "properties"
+  },
+  "properties-experience": {
+    "regex": "^Experience: (.+)$",
+    "type": "properties"
+  },
+  "properties-soulsPerUse": {
+    "regex": "^Souls Per Use: (.+)$",
+    "type": "properties"
+  },
+  "sockets": {
+    "regex": "^Sockets: (.+)$",
+    "type": "sockets"
+  },
+  "itemLevel": {
+    "regex": "^Item Level: ([0-9]+)$",
+    "type": "itemLevel"
+  },
+  "corrupted": {
+    "regex": "^Corrupted$",
+    "type": "corrupted"
+  },
+  "note": {
+    "regex": "^Note: (.+)$",
+    "type": "note"
+  }
+}

--- a/src/resource/templates/poeTrade.html
+++ b/src/resource/templates/poeTrade.html
@@ -1,0 +1,30 @@
+<div class="entry" data-id="%entry-id%">
+  <div class="title">
+    <div class="left">
+      <div class="button" data-link="%link%" style="display: none">
+        <i class="fas fa-external-link-square-alt grey"></i>
+      </div>
+    </div>
+    <div class="middle">
+      %item-name% <span class="grey">%item-baseType%</span>
+    </div>
+    <div class="right">
+      <div class="timeout" style="display: none"></div>
+      <div class="button" data-button="close" style="display: none">
+        <i class="fas fa-window-close grey"></i>
+      </div>
+    </div>
+  </div>
+  <div class="content center">
+    <div class="item">
+      <div class="price">
+        <img class="icon" alt="%item-name%" src="%item-icon%">
+        <i class="fas fa-arrow-right"></i>
+        <span class="value">%item-value-min%</span>
+        <span class="value grey">~</span>
+        <span class="value">%item-value-max%</span>
+        <img class="icon left-margin" alt="%currency-name%" src="%currency-icon%">
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/settings.html
+++ b/src/settings.html
@@ -22,6 +22,9 @@
         <div class="link" data-settings="price-check">
           <span class="label"><i class="fas fa-money-bill"></i> Price check</span>
         </div>
+        <div class="link" data-settings="poe-data">
+          <span class="label"><i class="fas fa-sync"></i> POE-Data API</span>
+        </div>
         <div class="link" data-settings="auto-close">
           <span class="label"><i class="fas fa-clock"></i> Auto-close</span>
         </div>
@@ -29,6 +32,7 @@
       </div>
       <div class="settings">
         <div class="content">
+
           <div data-settings="general">
             <div class="option">
               <div class="toggle" data-toggle="autoMinimize"><i class="fas fa-toggle-off grey"></i></div>
@@ -88,6 +92,7 @@
               </div>
             </div>
           </div>
+
           <div data-settings="price-check" style="display: none">
             <div class="option">
               <div class="toggle" data-toggle="pricecheck"><i class="fas fa-toggle-off grey"></i></div>
@@ -109,7 +114,102 @@
                 <select class="select" id="leagueSelect"></select>
               </label>
             </div>
+            <div class="title">
+              Pricecheck Provider
+            </div>
+            <div id="providerRare" class="option last-option">
+              <div class="label">
+                Rare items
+              </div>
+              <div class="description">
+                Please select the provider that should be used to fetch the price of rares.
+              </div>
+              <label class="wrap">
+                <select class="select" id="providerRareSelect">
+                  <option value="poeprices">poeprices.info</option>
+                  <option value="poetrade">pathofexile.com</option>
+                </select>
+              </label>
+            </div>
+            <div id="providerCurrency" class="option last-option">
+              <div class="label">
+                Currency items
+              </div>
+              <div class="description">
+                Please select the provider that should be used to fetch the ratios of curency.
+              </div>
+              <label class="wrap">
+                <select class="select" id="providerCurrencySelect">
+                  <option value="poeninja">poe.ninja</option>
+                </select>
+              </label>
+            </div>
+            <div id="providerOthers" class="option last-option">
+              <div class="label">
+                Other items
+              </div>
+              <div class="description">
+                Please select the provider that should be used to fetch the price of other items.
+              </div>
+              <label class="wrap">
+                <select class="select" id="providerOthersSelect">
+                  <option value="poeninja">poe.ninja</option>
+                  <option value="poetrade">pathofexile.com</option>
+                </select>
+              </label>
+            </div>
           </div>
+
+          <div data-settings="poe-data" style="display: none">
+            <div class="option">
+              <div class="label">
+                Update interval
+                <span class="slider-value"><span class="value"></span><span class="unit">day(s)</span></span>
+              </div>
+              <div class="description">
+                Defines the interval in which the item, mod and league data from the official APIs is updated.<br />
+                <div class="banner">
+                  <i class="fas fa-info-circle"></i> Setting this to 0 days will disable automatic updates.
+                </div>
+              </div>
+              <div class="slider" data-slider="poeDataInterval">
+                <div slider-min="0" slider-max="31" slider-step="1"></div>
+              </div>
+            </div>
+            <div id="poeDataLoginOption" class="option">
+              <div class="label">
+                Username
+                <span class="banner note">
+                  Optional
+                </span>
+              </div>
+              <div class="description">
+                Username for accessing the data of the path of exile wiki.<br />
+                You can create an login at
+                <a class="green" target="_blank" href="https://pathofexile.gamepedia.com/Special:BotPasswords">
+                  https://pathofexile.gamepedia.com/Special:BotPasswords
+                </a>
+              </div>
+              <label class="input">
+                <input type="text" class="text" id="poeDataLogin" />
+              </label>
+            </div>
+            <div id="poeDataPasswordOption" class="option">
+              <div class="label">
+                Password
+                <span class="banner note">
+                  Optional
+                </span>
+              </div>
+              <div class="description">
+                Password for accessing the data of the path of exile wiki.<br />
+              </div>
+              <label class="input">
+                <input type="password" class="text" id="poeDataPassword" />
+              </label>
+            </div>
+          </div>
+
           <div data-settings="auto-close" style="display: none">
             <div class="option">
               <div class="toggle" data-toggle="autoclose.enabled"><i class="fas fa-toggle-off grey"></i></div>
@@ -165,6 +265,7 @@
               </div>
             </div>
           </div>
+
         </div>
       </div>
   </body>


### PR DESCRIPTION
 - Added various data that can be grabbed from the official poe trading api and wiki
 - Added advanced item parser (including item mods, min-/max-rolls, sockets, ...)
 - Added first implementation of price checking for the official poe trading api
   - "src/resource/modPseudoMappings.json" contains some rules for combining certain mods into pseudo-mods when searching or ignoring some in certain cases
   - "src/modules/poetrade.js" function "getSearchQuery" contains the core logic for setting up the search parameters

I was already working on this for a few weeks, but after the poeprices.info api went down for multiple days (making this tool mostly unusable) I took the time this weekend and polished it as much as possible. It should leave the current functionality unchanged, but provide the option to use alternative providers in case of a downtime. In addition to that the "PoeData" class and extended item parser allows to get more detailed information about mod rolls and the item in general, which allows to provide additional information (e.g. notify about max rolls) and chances to improve the current workflow (e.g. automatically obtain league names, refine price estimates or fallback to different providers)

If there are any issues with my code, feel free to tell me about it and I will look into it as soon as I can. If you want to use this code for other projects, feel free to do so.